### PR TITLE
User Flash Settings Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+
+# Common editor extensions
+*~
+*.swp
+*.orig
+
+# Common output directories
+install/
+docs/html/
+docs/latex/
+
+# GitHub standard C++ gitignore
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/README.md
+++ b/README.md
@@ -4,28 +4,6 @@ Carnegie Robotics, LLC
 4501 Hatfield Street, Pittsburgh, PA 15201
 http://www.carnegierobotics.com
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-     * Redistributions of source code must retain the above copyright
-       notice, this list of conditions and the following disclaimer.
-     * Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
-     * Neither the name of the Carnegie Robotics, LLC nor the
-       names of its contributors may be used to endorse or promote products
-       derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL CARNEGIE ROBOTICS, LLC BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 # LibMultiSense
 
 LibMultiSense is a C++ library used to interface with the MultiSense S

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ family of sensors from Carnegie Robotics. For more information on the
 various MultiSense products please visit
 http://carnegierobotics.com/products/
 
+LibMultiSense was previously hosted as a Mercurial repository on Bitbucket
+with the following URL: https://bitbucket.org/crl/libmultisense
+
 ### Installation
 
 #### Linux
@@ -41,13 +44,13 @@ LibMultiSense uses CMake for its build system.
 
 To build the standalone LibMultiSense library and demonstration applications.
 
-    > hg clone http://bitbucket.org/crl/LibMultiSense
+    > git clone git@github.com:carnegierobotics/LibMultiSense.git
     > cd LibMultiSense
     > mkdir build
     > cd build && cmake ..
     > make
 
-Integrating LibMultiSense into an existing CMake project is easy. Simply 
+Integrating LibMultiSense into an existing CMake project is easy. Simply
 clone the LibMultiSense repository into the existing project's source tree.
  In the main CMakeLists.txt file of the project, add the following lines:
 
@@ -63,8 +66,7 @@ to build the LibMultiSense DLL.
 Download and install CMake on Windows (http://www.cmake.org/download/), making
 sure CMake is included included in the system PATH.
 
-Clone LibMultiSense to the Windows machine using a Windows Mercurial client.
-TortiseHg works well for this application http://tortoisehg.bitbucket.org/
+Clone LibMultiSense to the Windows machine using a Windows Git client.
 
 Open a command prompt and execute the following commands:
 
@@ -98,9 +100,8 @@ Usage examples are included in the Doxygen documentation.
 
 ###Support
 
-Please direct all issues, questions, and feature requests to
-support@carnegierobotics.com
+To report an issue with this library or request a new feature,
+please use the [GitHub issues system](https://github.com/carnegierobotics/LibMultiSense/issues)
 
-
-
-
+For product support, please see the [support section of our website](https://carnegierobotics.com/support)
+Individual support requests can be created in our [support portal](https://support.carnegierobotics.com/hc/en-us)

--- a/source/LibMultiSense/MultiSenseChannel.hh
+++ b/source/LibMultiSense/MultiSenseChannel.hh
@@ -1043,7 +1043,7 @@ public:
 };
 
 
-}; // namespace multisense
-}; // namespace crl
+} // namespace multisense
+} // namespace crl
 
 #endif // LibMultiSense_MultiSenseChannel_hh

--- a/source/LibMultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/MultiSenseTypes.hh
@@ -135,7 +135,9 @@ static CRL_CONSTEXPR DataSource Source_Pps                    = (1<<26);
 
 /**
  * Class used to request that MultiSense data be sent to a 3rd-party
- * stream destination (UDP port).
+ * stream destination (UDP port), currently supported only by CRL's
+ * Monocular IP Camera.  This functionality is not supported by any of
+ * CRL's stereo sensor products.
  */
 class MULTISENSE_API DirectedStream {
 public:
@@ -697,6 +699,16 @@ public:
 
     void setHdr                     (bool  e)    { m_hdrEnabled  = e;    };
 
+    /**
+     * Set the flag to write the image configuration to flash. This will
+     * result in the camera defaulting to these settings on boot.
+     * NOTE: This should be enabled sparingly. The MultiSense flash has a
+     * limited number of writes
+     *
+     * @param e A boolean used to enable or disable writing the camera
+     *          configuration to flash
+     */
+    void setStoreSettingsInFlash    (bool e)     {m_storeSettingsInFlash = e;    };
 
     //
     // Query
@@ -853,7 +865,12 @@ public:
      */
     bool     hdrEnabled              () const { return m_hdrEnabled;  };
 
-
+    /**
+     * Query the current image configuration's flag to write parameters to flash
+     *
+     * @return The current image configuration's write to flash flag
+     */
+    bool     storeSettingsInFlash    () const { return m_storeSettingsInFlash; };
 
     //
     // Query camera calibration (read-only)
@@ -975,7 +992,8 @@ public:
     Config() : m_fps(5.0f), m_gain(1.0f),
                m_exposure(10000), m_aeEnabled(true), m_aeMax(5000000), m_aeDecay(7), m_aeThresh(0.75f),
                m_wbBlue(1.0f), m_wbRed(1.0f), m_wbEnabled(true), m_wbDecay(3), m_wbThresh(0.5f),
-               m_width(1024), m_height(544), m_disparities(128), m_cam_mode(0), m_offset(-1), m_spfStrength(0.5f), m_hdrEnabled(false),
+               m_width(1024), m_height(544), m_disparities(128), m_cam_mode(0), m_offset(-1), m_spfStrength(0.5f),
+               m_hdrEnabled(false), m_storeSettingsInFlash(false),
                m_fx(0), m_fy(0), m_cx(0), m_cy(0),
                m_tx(0), m_ty(0), m_tz(0), m_roll(0), m_pitch(0), m_yaw(0) {};
 private:
@@ -997,6 +1015,7 @@ private:
     int      m_offset;
     float    m_spfStrength;
     bool     m_hdrEnabled;
+    bool     m_storeSettingsInFlash;
 
 protected:
 
@@ -1205,6 +1224,10 @@ public:
      * to the left imager, index 1 corresponds to the right imager */
     int16_t bl_offset[2];
 
+    /** The imager vramp pair for each imager. Index 0 corresponds
+    * to the left imager, index 1 corresponds to the right imager */
+    uint8_t vramp[2];
+
 };
 
 class MULTISENSE_API TransmitDelay {
@@ -1272,7 +1295,7 @@ public:
     std::vector<uint32_t> data;
 };
 
-}; // namespace image
+} // namespace image
 
 
 
@@ -1431,7 +1454,7 @@ public:
     float cameraToSpindleFixed[4][4];
 };
 
-}; // namespace lidar
+} // namespace lidar
 
 
 
@@ -1442,8 +1465,6 @@ namespace lighting {
 static CRL_CONSTEXPR uint32_t MAX_LIGHTS     = 8;
 /** The maximum duty cycle for adjusting light intensity */
 static CRL_CONSTEXPR float    MAX_DUTY_CYCLE = 100.0;
-/** The maxmimum value of the ambient light sensor */
-static CRL_CONSTEXPR float    MAX_AMBIENT_LIGHTING = 100.0;
 
 /**
  * Class used to store a specific lighting configuration. Member of this class
@@ -1666,7 +1687,7 @@ public:
     SensorStatus() : ambientLightPercentage(100.0f) {};
 };
 
-}; // namespace lighting
+} // namespace lighting
 
 
 
@@ -1982,7 +2003,7 @@ public:
     uint32_t    rangeTableIndex;
 };
 
-}; // namespace imu
+} // namespace imu
 
 
 
@@ -2593,9 +2614,9 @@ class MULTISENSE_API ExternalCalibration {
             yaw(0.) {};
 };
 
-}; // namespace system
-}; // namespace multisense
-}; // namespace crl
+} // namespace system
+} // namespace multisense
+} // namespace crl
 
 #if defined (_MSC_VER)
 #pragma warning (pop)

--- a/source/LibMultiSense/details/public.cc
+++ b/source/LibMultiSense/details/public.cc
@@ -113,15 +113,15 @@ CRL_THREAD_LOCAL utility::BufferStream *dispatchBufferReferenceTP = NULL;
 //
 // Adds a new image listener
 
-Status impl::addIsolatedCallback(image::Callback callback, 
+Status impl::addIsolatedCallback(image::Callback callback,
                                  DataSource     imageSourceMask,
                                  void           *userDataP)
 {
     try {
 
         utility::ScopedLock lock(m_dispatchLock);
-        m_imageListeners.push_back(new ImageListener(callback, 
-                                                     imageSourceMask, 
+        m_imageListeners.push_back(new ImageListener(callback,
+                                                     imageSourceMask,
                                                      userDataP,
                                                      MAX_USER_IMAGE_QUEUE_SIZE));
 
@@ -135,13 +135,13 @@ Status impl::addIsolatedCallback(image::Callback callback,
 //
 // Adds a new laser listener
 
-Status impl::addIsolatedCallback(lidar::Callback callback, 
+Status impl::addIsolatedCallback(lidar::Callback callback,
                                  void           *userDataP)
 {
     try {
 
         utility::ScopedLock lock(m_dispatchLock);
-        m_lidarListeners.push_back(new LidarListener(callback, 
+        m_lidarListeners.push_back(new LidarListener(callback,
                                                      0,
                                                      userDataP,
                                                      MAX_USER_LASER_QUEUE_SIZE));
@@ -156,13 +156,13 @@ Status impl::addIsolatedCallback(lidar::Callback callback,
 //
 // Adds a new PPS listener
 
-Status impl::addIsolatedCallback(pps::Callback callback, 
+Status impl::addIsolatedCallback(pps::Callback callback,
                                  void         *userDataP)
 {
     try {
 
         utility::ScopedLock lock(m_dispatchLock);
-        m_ppsListeners.push_back(new PpsListener(callback, 
+        m_ppsListeners.push_back(new PpsListener(callback,
                                                  0,
                                                  userDataP,
                                                  MAX_USER_PPS_QUEUE_SIZE));
@@ -177,13 +177,13 @@ Status impl::addIsolatedCallback(pps::Callback callback,
 //
 // Adds a new IMU listener
 
-Status impl::addIsolatedCallback(imu::Callback callback, 
+Status impl::addIsolatedCallback(imu::Callback callback,
                                  void         *userDataP)
 {
     try {
 
         utility::ScopedLock lock(m_dispatchLock);
-        m_imuListeners.push_back(new ImuListener(callback, 
+        m_imuListeners.push_back(new ImuListener(callback,
                                                  0,
                                                  userDataP,
                                                  MAX_USER_IMU_QUEUE_SIZE));
@@ -207,7 +207,7 @@ Status impl::removeIsolatedCallback(image::Callback callback)
         for(it  = m_imageListeners.begin();
             it != m_imageListeners.end();
             it ++) {
-        
+
             if ((*it)->callback() == callback) {
                 delete *it;
                 m_imageListeners.erase(it);
@@ -235,7 +235,7 @@ Status impl::removeIsolatedCallback(lidar::Callback callback)
         for(it  = m_lidarListeners.begin();
             it != m_lidarListeners.end();
             it ++) {
-        
+
             if ((*it)->callback() == callback) {
                 delete *it;
                 m_lidarListeners.erase(it);
@@ -263,7 +263,7 @@ Status impl::removeIsolatedCallback(pps::Callback callback)
         for(it  = m_ppsListeners.begin();
             it != m_ppsListeners.end();
             it ++) {
-        
+
             if ((*it)->callback() == callback) {
                 delete *it;
                 m_ppsListeners.erase(it);
@@ -291,7 +291,7 @@ Status impl::removeIsolatedCallback(imu::Callback callback)
         for(it  = m_imuListeners.begin();
             it != m_imuListeners.end();
             it ++) {
-        
+
             if ((*it)->callback() == callback) {
                 delete *it;
                 m_imuListeners.erase(it);
@@ -317,13 +317,13 @@ void *impl::reserveCallbackBuffer()
         try {
 
             return reinterpret_cast<void*>(new utility::BufferStream(*dispatchBufferReferenceTP));
-            
+
         } catch (const std::exception& e) {
-            
+
             CRL_DEBUG("exception: %s\n", e.what());
-            
+
         } catch (...) {
-            
+
             CRL_DEBUG("unknown exception\n");
         }
     }
@@ -343,12 +343,12 @@ Status impl::releaseCallbackBuffer(void *referenceP)
             return Status_Ok;
 
         } catch (const std::exception& e) {
-            
+
             CRL_DEBUG("exception: %s\n", e.what());
             return Status_Exception;
-            
+
         } catch (...) {
-            
+
             CRL_DEBUG("unknown exception\n");
             return Status_Exception;
         }
@@ -364,12 +364,12 @@ Status impl::getImageHistogram(int64_t           frameId,
                                image::Histogram& histogram)
 {
     try {
-        
+
         utility::ScopedLock lock(m_imageMetaCache.mutex());
 
         const wire::ImageMeta *metaP = m_imageMetaCache.find_nolock(frameId);
         if (NULL == metaP) {
-            CRL_DEBUG("no meta cached for frameId %ld", 
+            CRL_DEBUG("no meta cached for frameId %ld",
                       static_cast<long int>(frameId));
             return Status_Failed;
         }
@@ -492,7 +492,7 @@ Status impl::getDirectedStreams(std::vector<DirectedStream>& streams)
     status = waitData(wire::SysGetDirectedStreams(), rsp);
     if (Status_Ok != status)
         return status;
-    
+
     std::vector<wire::DirectedStream>::const_iterator it = rsp.streams.begin();
     for(; it != rsp.streams.end(); ++it)
         streams.push_back(DirectedStream((*it).mask,
@@ -516,7 +516,7 @@ Status impl::setTriggerSource(TriggerSource s)
     uint32_t wireSource;
 
     switch(s) {
-    case Trigger_Internal: 
+    case Trigger_Internal:
 
         wireSource = wire::CamSetTriggerSource::SOURCE_INTERNAL;
         break;
@@ -553,7 +553,7 @@ Status impl::getLightingConfig(lighting::Config& c)
     status = waitData(wire::LedGetStatus(), data);
     if (Status_Ok != status)
         return status;
-        
+
     for(uint32_t i=0; i<lighting::MAX_LIGHTS; i++) {
         float duty=0.0f;
         if ((1<<i) & data.available)
@@ -572,7 +572,7 @@ Status impl::setLightingConfig(const lighting::Config& c)
 
     msg.flash = c.getFlash() ? 1 : 0;
     for(uint32_t i=0; i<lighting::MAX_LIGHTS; i++) {
-      
+
         float duty = c.getDutyCycle(i);
         if (duty >= 0.0f) {  // less than zero == not set
             msg.mask |= (1<<i);
@@ -650,14 +650,14 @@ Status impl::getImageConfig(image::Config& config)
                     float tx, float ty, float tz,
                     float r,  float p,  float w) {
             m_fx = fx; m_fy = fy; m_cx = cx; m_cy = cy;
-            m_tx = tx; m_ty = ty; m_tz = tz; 
+            m_tx = tx; m_ty = ty; m_tz = tz;
             m_roll = r; m_pitch = p; m_yaw = w;
         };
     };
-      
+
     // what is the proper c++ cast for this?
     ConfigAccess& a = *((ConfigAccess *) &config);
-    
+
     a.setResolution(d.width, d.height);
     if (-1 == d.disparities) { // pre v2.3 firmware
         if (1024 == d.width)   // TODO: check for monocular
@@ -668,13 +668,13 @@ Status impl::getImageConfig(image::Config& config)
     a.setDisparities(d.disparities);
     a.setFps(d.framesPerSecond);
     a.setGain(d.gain);
-    
+
     a.setExposure(d.exposure);
     a.setAutoExposure(d.autoExposure != 0);
     a.setAutoExposureMax(d.autoExposureMax);
     a.setAutoExposureDecay(d.autoExposureDecay);
     a.setAutoExposureThresh(d.autoExposureThresh);
-    
+
     a.setWhiteBalance(d.whiteBalanceRed, d.whiteBalanceBlue);
     a.setAutoWhiteBalance(d.autoWhiteBalance != 0);
     a.setAutoWhiteBalanceDecay(d.autoWhiteBalanceDecay);
@@ -682,10 +682,10 @@ Status impl::getImageConfig(image::Config& config)
     a.setStereoPostFilterStrength(d.stereoPostFilterStrength);
     a.setHdr(d.hdrEnabled);
 
-    a.setCal(d.fx, d.fy, d.cx, d.cy, 
+    a.setCal(d.fx, d.fy, d.cx, d.cy,
              d.tx, d.ty, d.tz,
              d.roll, d.pitch, d.yaw);
-    
+
     return Status_Ok;
 }
 
@@ -699,7 +699,7 @@ Status impl::setImageConfig(const image::Config& c)
 {
     Status status;
 
-    status = waitAck(wire::CamSetResolution(c.width(), 
+    status = waitAck(wire::CamSetResolution(c.width(),
                                             c.height(),
                                             c.disparities(),
                                             c.camMode(),
@@ -711,7 +711,7 @@ Status impl::setImageConfig(const image::Config& c)
 
     cmd.framesPerSecond = c.fps();
     cmd.gain            = c.gain();
-    
+
     cmd.exposure           = c.exposure();
     cmd.autoExposure       = c.autoExposure() ? 1 : 0;
     cmd.autoExposureMax    = c.autoExposureMax();
@@ -725,6 +725,7 @@ Status impl::setImageConfig(const image::Config& c)
     cmd.autoWhiteBalanceThresh   = c.autoWhiteBalanceThresh();
     cmd.stereoPostFilterStrength = c.stereoPostFilterStrength();
     cmd.hdrEnabled               = c.hdrEnabled();
+    cmd.storeSettingsInFlash     = c.storeSettingsInFlash();
 
     return waitAck(cmd);
 }
@@ -785,6 +786,7 @@ Status impl::getSensorCalibration(image::SensorCalibration& c)
         return status;
     CPY_ARRAY_1(c.adc_gain, d.adc_gain, 2);
     CPY_ARRAY_1(c.bl_offset, d.bl_offset, 2);
+    CPY_ARRAY_1(c.vramp, d.vramp, 2);
 
     return Status_Ok;
 }
@@ -798,6 +800,7 @@ Status impl::setSensorCalibration(const image::SensorCalibration& c)
 
     CPY_ARRAY_1(d.adc_gain, c.adc_gain, 2);
     CPY_ARRAY_1(d.bl_offset, c.bl_offset, 2);
+    CPY_ARRAY_1(d.vramp, c.vramp, 2);
 
     return waitAck(d);
 }
@@ -873,7 +876,7 @@ Status impl::getDeviceModes(std::vector<system::DeviceMode>& modes)
     modes.resize(d.modes.size());
     for(uint32_t i=0; i<d.modes.size(); i++) {
 
-        system::DeviceMode&     a = modes[i]; 
+        system::DeviceMode&     a = modes[i];
         const wire::DeviceMode& w = d.modes[i];
 
         a.width                = w.width;
@@ -881,10 +884,10 @@ Status impl::getDeviceModes(std::vector<system::DeviceMode>& modes)
         a.supportedDataSources = sourceWireToApi(w.supportedDataSources);
         if (m_sensorVersion.firmwareVersion >= 0x0203)
             a.disparities = w.disparities;
-        else 
+        else
             a.disparities = (a.width == 1024) ? 128 : 0;
     }
-                        
+
     return Status_Ok;
 }
 
@@ -976,7 +979,7 @@ Status impl::getDeviceInfo(system::DeviceInfo& info)
 
         info.pcbs.push_back(pcb);
     }
-        
+
     info.imagerName              = w.imagerName;
     info.imagerType              = imagerWireToApi(w.imagerType);
     info.imagerWidth             = w.imagerWidth;
@@ -1078,13 +1081,13 @@ Status impl::setDeviceInfo(const std::string& key,
     w.buildDate        = info.buildDate;
     w.serialNumber     = info.serialNumber;
     w.hardwareRevision = hardwareApiToWire(info.hardwareRevision);
-    w.numberOfPcbs     = std::min((uint32_t) info.pcbs.size(), 
+    w.numberOfPcbs     = std::min((uint32_t) info.pcbs.size(),
                                   (uint32_t) wire::SysDeviceInfo::MAX_PCBS);
     for(uint32_t i=0; i<w.numberOfPcbs; i++) {
         w.pcbs[i].name     = info.pcbs[i].name;
         w.pcbs[i].revision = info.pcbs[i].revision;
     }
-        
+
     w.imagerName              = info.imagerName;
     w.imagerType              = imagerApiToWire(info.imagerType);
     w.imagerWidth             = info.imagerWidth;
@@ -1169,7 +1172,7 @@ Status impl::getImuInfo(uint32_t& maxSamplesPerMessage,
         info[i].name   = d.name;
         info[i].device = d.device;
         info[i].units  = d.units;
-        
+
         info[i].rates.resize(d.rates.size());
         for(uint32_t j=0; j<d.rates.size(); j++) {
             info[i].rates[j].sampleRate      = d.rates[j].sampleRate;
@@ -1245,7 +1248,7 @@ Status impl::getLargeBufferDetails(uint32_t& bufferCount,
 {
     bufferCount = RX_POOL_LARGE_BUFFER_COUNT;
     bufferSize  = RX_POOL_LARGE_BUFFER_SIZE;
-    
+
     return Status_Ok;
 }
 
@@ -1257,17 +1260,17 @@ Status impl::setLargeBuffers(const std::vector<uint8_t*>& buffers,
 {
     if (buffers.size() < RX_POOL_LARGE_BUFFER_COUNT)
         CRL_DEBUG("WARNING: supplying less than recommended number of large buffers: %ld/%ld\n",
-                  static_cast<long int>(buffers.size()), 
+                  static_cast<long int>(buffers.size()),
                   static_cast<long int>(RX_POOL_LARGE_BUFFER_COUNT));
     if (bufferSize < RX_POOL_LARGE_BUFFER_SIZE)
         CRL_DEBUG("WARNING: supplying smaller than recommended large buffers: %ld/%ld bytes\n",
-                  static_cast<long int>(bufferSize), 
+                  static_cast<long int>(bufferSize),
                   static_cast<long int>(RX_POOL_LARGE_BUFFER_SIZE));
 
     try {
 
         utility::ScopedLock lock(m_rxLock); // halt potential pool traversal
-        
+
         //
         // Deletion is safe even if the buffer is in use elsewhere
         // (BufferStream is reference counted.)

--- a/source/LibMultiSense/details/wire/CamControlMessage.h
+++ b/source/LibMultiSense/details/wire/CamControlMessage.h
@@ -50,14 +50,14 @@ namespace wire {
 class CamControl {
 public:
     static CRL_CONSTEXPR IdType      ID      = ID_CMD_CAM_CONTROL;
-    static CRL_CONSTEXPR VersionType VERSION = 3;
+    static CRL_CONSTEXPR VersionType VERSION = 4;
 
     //
     // Parameters representing the current camera configuration
 
     float    framesPerSecond;
     float    gain;
-    
+
     uint32_t exposure;
     uint8_t  autoExposure;
     uint32_t autoExposureMax;
@@ -79,6 +79,11 @@ public:
     // Additions in version 3
 
     bool     hdrEnabled;
+
+    //
+    // Additions in version 4
+
+    bool  storeSettingsInFlash;  // boolean
 
     //
     // Constructors
@@ -117,6 +122,11 @@ public:
             message & hdrEnabled;
         else
             hdrEnabled = false;
+
+        if (version >= 4)
+            message & storeSettingsInFlash;
+        else
+            storeSettingsInFlash = false;
     }
 };
 

--- a/source/LibMultiSense/details/wire/CamSetTriggerSourceMessage.h
+++ b/source/LibMultiSense/details/wire/CamSetTriggerSourceMessage.h
@@ -53,6 +53,7 @@ public:
 
     static CRL_CONSTEXPR uint32_t    SOURCE_INTERNAL = 0;
     static CRL_CONSTEXPR uint32_t    SOURCE_EXTERNAL = 1; // OPTO_RX
+    static CRL_CONSTEXPR uint32_t    SOURCE_EXTERNAL_INVERTED = 2; // OPTO_RX
 
     //
     // Parameters

--- a/source/LibMultiSense/details/wire/SysDeviceInfoMessage.h
+++ b/source/LibMultiSense/details/wire/SysDeviceInfoMessage.h
@@ -99,6 +99,7 @@ public:
     static CRL_CONSTEXPR uint32_t LIGHTING_TYPE_NONE = 0;
     static CRL_CONSTEXPR uint32_t LIGHTING_TYPE_SL_INTERNAL = 1;
     static CRL_CONSTEXPR uint32_t LIGHTING_TYPE_S21_EXTERNAL = 2;
+    static CRL_CONSTEXPR uint32_t LIGHTING_TYPE_S21_PATTERN_PROJECTOR = 3;
 
     std::string key;
     std::string name;

--- a/source/LibMultiSense/details/wire/SysSensorCalibrationMessage.h
+++ b/source/LibMultiSense/details/wire/SysSensorCalibrationMessage.h
@@ -49,11 +49,15 @@ namespace wire {
 class SysSensorCalibration {
 public:
     static CRL_CONSTEXPR IdType      ID      = ID_DATA_SYS_SENSOR_CAL;
-    static CRL_CONSTEXPR VersionType VERSION = 1;
+    static CRL_CONSTEXPR VersionType VERSION = 2;
 
 
     uint8_t adc_gain[2];
     int16_t bl_offset[2];
+
+    //version 2
+
+    uint8_t vramp[2];
 
     //
     // Constructors
@@ -70,6 +74,13 @@ public:
     {
         SER_ARRAY_1(adc_gain,2);
         SER_ARRAY_1(bl_offset,2);
+
+        if(version >=2) {
+        	SER_ARRAY_1(vramp,2);
+        } else {
+            vramp[0] = 109;
+            vramp[1] = 109;
+        }
     }
 };
 

--- a/source/Utilities/SensorCalUtility/SensorCalUtility.cc
+++ b/source/Utilities/SensorCalUtility/SensorCalUtility.cc
@@ -220,9 +220,10 @@ int main(int    argc,
 
     if (false == setCal) {
 
-        fprintf(stdout,"left sensor gain: %hu\nright sensor gain %hu\nleft sensor black level: %d\nright sensor black level %d\n", 
+        fprintf(stdout,"left sensor gain: %hu\nright sensor gain %hu\nleft sensor black level: %d\nright sensor black level %d\nleft sensor vramp: %d\nright sensor vramp %d\n", 
                     sensorCalibration.adc_gain[0], sensorCalibration.adc_gain[1],
-                    sensorCalibration.bl_offset[0], sensorCalibration.bl_offset[1]);
+                    sensorCalibration.bl_offset[0], sensorCalibration.bl_offset[1],
+                    sensorCalibration.vramp[0], sensorCalibration.vramp[1]);
 
     } else {
 


### PR DESCRIPTION
Camera setting messages have been updated to allow the user to choose whether or not setting updates will be stored in the cameras flash. Storing in the flash will make settings persistent after power cycling. This option was added because there are a finite number of write cycles before flash failure, and losing power while writing tho the flash can corrupt it. It is recommended that most users do not write the camera settings to flash except when choosing default settings during camera commissioning. 

Messages for modifying the imager VRAMP settings were also added. In almost all cases, these values will not need to be modified by end users.

Trailing whitespace and unnecessary semicolons have been removed in many files