### PR TITLE
Clean Up Installation Steps to Use Install Prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 *.orig
 
 # Common output directories
+build/
+bin/
+lib/
+share/
 install/
 docs/html/
 docs/latex/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+
+# Common editor extensions
+*~
+*.swp
+*.orig
+
+# Common output directories
+install/
+docs/html/
+docs/latex/
+
+# GitHub standard C++ gitignore
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-# @file CMakeLists.txt 
-# 
+# @file CMakeLists.txt
+#
 # Top level build instructions.
 #
 
@@ -11,64 +11,38 @@ cmake_minimum_required(VERSION 2.8)
 
 project(LibMultiSense)
 
+add_compile_options(-Wall -Wextra -Werror -Wpedantic)
+
+option (MULTISENSE_BUILD_UTILITIES "Build MultiSense utility applications. Defaults to ON for backwards compatibility." ON)
+
+#
+# We want to build "Release" by default
+#
+
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "Selecting default build type: Release")
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type (default: Release)" FORCE)
+endif ()
+
+#
 # For Backwards compatablity with other ROS builds
+#
 if (BASE_DIRECTORY)
 else()
     set(BASE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
     set(SOURCE_DIRECTORY )
 endif()
 
-# Define where the result of the build should go.
-
-if (CMAKE_RUNTIME_OUTPUT_DIRECTORY)
-else()
-  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${BASE_DIRECTORY}/bin)
-endif()
-
-if (CMAKE_LIBRARY_OUTPUT_DIRECTORY)
-else()
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${BASE_DIRECTORY}/bin)
-endif()
+#
+# Use full RPATH
+#
+set (CMAKE_SKIP_BUILD_RPATH FALSE)
+set (CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+set (CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
+set (CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 #
-# We want to build "Release" by default
-#
-
-if (CMAKE_BUILD_TYPE)
-else()
-  set(CMAKE_BUILD_TYPE "Release")
-endif()
-
-#
-# Turn on optimizations and maximum warnings.
-#
-
-# Turn on debugging symbols / optimizations and warnings.  To choose
-# which build type, use "cmake -DCMAKE_BUILD_TYPE=Debug <directory>" or
-# "cmake -DCMAKE_BUILD_TYPE=Release <directory>".
-
-if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-
-    set(CMAKE_C_FLAGS_DEBUG "-Zi -W3")
-    set(CMAKE_CXX_FLAGS_DEBUG "-Zi -W3")
-
-    set(CMAKE_C_FLAGS_RELEASE "-Zi -O2 -W3 -Gy -Oy")
-    set(CMAKE_CXX_FLAGS_RELEASE "-Zi -O2 -W3 -Gy -Oy")
-
-	#TODO: MSVC warns about deprecated functions. These 
-    add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS)
-
-else ()
-
-    set(CMAKE_C_FLAGS_DEBUG "-g -Wall -fstrict-aliasing")
-    set(CMAKE_CXX_FLAGS_DEBUG "-g -Wall -fstrict-aliasing")
-
-    set(CMAKE_C_FLAGS_RELEASE "-g -O2 -Wall -ffunction-sections -fomit-frame-pointer -Wall -fstrict-aliasing")
-    set(CMAKE_CXX_FLAGS_RELEASE "-g -O2 -Wall -ffunction-sections -fomit-frame-pointer -Wall -fstrict-aliasing")
-
-endif ()
-
 # Dispatch to subordinate CMakeList.txt files.
+#
 
 add_subdirectory(source)
-

--- a/README.md
+++ b/README.md
@@ -4,28 +4,6 @@ Carnegie Robotics, LLC
 4501 Hatfield Street, Pittsburgh, PA 15201
 http://www.carnegierobotics.com
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-     * Redistributions of source code must retain the above copyright
-       notice, this list of conditions and the following disclaimer.
-     * Redistributions in binary form must reproduce the above copyright
-       notice, this list of conditions and the following disclaimer in the
-       documentation and/or other materials provided with the distribution.
-     * Neither the name of the Carnegie Robotics, LLC nor the
-       names of its contributors may be used to endorse or promote products
-       derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL CARNEGIE ROBOTICS, LLC BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 # LibMultiSense
 
 LibMultiSense is a C++ library used to interface with the MultiSense S

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ family of sensors from Carnegie Robotics. For more information on the
 various MultiSense products please visit
 http://carnegierobotics.com/products/
 
+LibMultiSense was previously hosted as a Mercurial repository on Bitbucket
+with the following URL: https://bitbucket.org/crl/libmultisense
+
 ### Installation
 
 #### Linux
@@ -41,13 +44,13 @@ LibMultiSense uses CMake for its build system.
 
 To build the standalone LibMultiSense library and demonstration applications.
 
-    > hg clone http://bitbucket.org/crl/LibMultiSense
+    > git clone git@github.com:carnegierobotics/LibMultiSense.git
     > cd LibMultiSense
     > mkdir build
     > cd build && cmake ..
     > make
 
-Integrating LibMultiSense into an existing CMake project is easy. Simply 
+Integrating LibMultiSense into an existing CMake project is easy. Simply
 clone the LibMultiSense repository into the existing project's source tree.
  In the main CMakeLists.txt file of the project, add the following lines:
 
@@ -63,8 +66,7 @@ to build the LibMultiSense DLL.
 Download and install CMake on Windows (http://www.cmake.org/download/), making
 sure CMake is included included in the system PATH.
 
-Clone LibMultiSense to the Windows machine using a Windows Mercurial client.
-TortiseHg works well for this application http://tortoisehg.bitbucket.org/
+Clone LibMultiSense to the Windows machine using a Windows Git client.
 
 Open a command prompt and execute the following commands:
 
@@ -98,9 +100,8 @@ Usage examples are included in the Doxygen documentation.
 
 ###Support
 
-Please direct all issues, questions, and feature requests to
-support@carnegierobotics.com
+To report an issue with this library or request a new feature,
+please use the [GitHub issues system](https://github.com/carnegierobotics/LibMultiSense/issues)
 
-
-
-
+For product support, please see the [support section of our website](https://carnegierobotics.com/support)
+Individual support requests can be created in our [support portal](https://support.carnegierobotics.com/hc/en-us)

--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ To build the standalone LibMultiSense library and demonstration applications.
     > git clone git@github.com:carnegierobotics/LibMultiSense.git
     > cd LibMultiSense
     > mkdir build
-    > cd build && cmake ..
+    > cd build && cmake -DCMAKE_INSTALL_PREFIX=../install ..
     > make
+
+To build the standalone LibMultiSense library without the demonstration applications,
+set the cmake variable `-DMULTISENSE_BUILD_UTILITIES=OFF`
 
 Integrating LibMultiSense into an existing CMake project is easy. Simply
 clone the LibMultiSense repository into the existing project's source tree.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-LibMultiSense
-Copyright 2014
-Carnegie Robotics, LLC
-4501 Hatfield Street, Pittsburgh, PA 15201
-http://www.carnegierobotics.com
-
 # LibMultiSense
 
 LibMultiSense is a C++ library used to interface with the MultiSense S

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -7,4 +7,7 @@
 #
 
 add_subdirectory(LibMultiSense)
-add_subdirectory(Utilities)
+
+if (${MULTISENSE_BUILD_UTILITIES})
+    add_subdirectory(Utilities)
+endif ()

--- a/source/LibMultiSense/CMakeLists.txt
+++ b/source/LibMultiSense/CMakeLists.txt
@@ -58,6 +58,8 @@ set_target_properties(MultiSense PROPERTIES VERSION "3.8")
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     target_link_libraries(MultiSense ws2_32)
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    target_link_libraries(MultiSense pthread)
 else()
     target_link_libraries(MultiSense pthread rt)
 endif()

--- a/source/LibMultiSense/CMakeLists.txt
+++ b/source/LibMultiSense/CMakeLists.txt
@@ -66,9 +66,13 @@ endif()
 
 # create install targets
 install(TARGETS MultiSense
+  EXPORT MultiSenseConfig
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
 )
+
+install(EXPORT MultiSenseConfig
+    DESTINATION lib/cmake/MultiSense)
 
 install(FILES ${MULTISENSE_HEADERS} DESTINATION include/MultiSense)

--- a/source/LibMultiSense/MultiSenseChannel.hh
+++ b/source/LibMultiSense/MultiSenseChannel.hh
@@ -752,6 +752,20 @@ public:
     virtual Status getMtu              (int32_t& mtu)                       = 0;
 
     /**
+     * Query the maxon or SLB motor for its current encoder position in
+     * microradians.
+     *
+     * @param mtu An int32_t returned by reference containing the current
+     * motor encoder position in microradians
+     *
+     * @return A crl::multisense::Status indicating success if a motor was
+     * found and could report its encoder position, or fail if no motor
+     * is present.
+     */
+
+    virtual Status getMotorPos          (int32_t& mtu)                      = 0;
+
+    /**
      * Set the current sensor's MTU.
      *
      * @param mtu The new MTU to configure the sensor with

--- a/source/LibMultiSense/MultiSenseChannel.hh
+++ b/source/LibMultiSense/MultiSenseChannel.hh
@@ -1043,7 +1043,7 @@ public:
 };
 
 
-}; // namespace multisense
-}; // namespace crl
+} // namespace multisense
+} // namespace crl
 
 #endif // LibMultiSense_MultiSenseChannel_hh

--- a/source/LibMultiSense/MultiSenseChannel.hh
+++ b/source/LibMultiSense/MultiSenseChannel.hh
@@ -391,11 +391,6 @@ public:
     /**
      * Start a directed stream used to stream data to multiple 3rd parties.
      *
-     * NOTE: Directed streams are currently only supported by CRL's
-     *       Monocular IP Camera.  MultiSense S* hardware variations
-     *       are not supported (the following functions will return
-     *       the 'Status_Unknown' error code.)
-     *
      * Secondary stream control.  In addition to the primary stream control
      * above, a set of streams may be directed to a 3rd party (or multiple
      * 3rd parties), where a 3rd party is uniquely defined as an IP address /
@@ -419,11 +414,6 @@ public:
 
     /**
      * Start several directed streams used to stream data to multiple 3rd parties.
-     *
-     * NOTE: Directed streams are currently only supported by CRL's
-     *       Monocular IP Camera.  MultiSense S* hardware variations
-     *       are not supported (the following functions will return
-     *       the 'Status_Unknown' error code.)
      *
      * Secondary stream control.  In addition to the primary stream control
      * above, a set of streams may be directed to a 3rd party (or multiple
@@ -449,11 +439,6 @@ public:
     /**
      * Stop a specific directed stream.
      *
-     * NOTE: Directed streams are currently only supported by CRL's
-     *       Monocular IP Camera.  MultiSense S* hardware variations
-     *       are not supported (the following functions will return
-     *       the 'Status_Unknown' error code.)
-     *
      * @param stream A DirectedStream to stop
      *
      * @return A crl::multisense::Status indicating if the DirectedStream was
@@ -464,11 +449,6 @@ public:
 
     /**
      * Get the current list of active streams.
-     *
-     * NOTE: Directed streams are currently only supported by CRL's
-     *       Monocular IP Camera.  MultiSense S* hardware variations
-     *       are not supported (the following functions will return
-     *       the 'Status_Unknown' error code.)
      *
      * @param streams A vector of DirectedStreams which is populated by
      * getDirectedStreams()
@@ -481,11 +461,6 @@ public:
 
     /**
      * Query the number of simultaneous parties which can be supported.
-     *
-     * NOTE: Directed streams are currently only supported by CRL's
-     *       Monocular IP Camera.  MultiSense S* hardware variations
-     *       are not supported (the following functions will return
-     *       the 'Status_Unknown' error code.)
      *
      * If the number of maximum directed streams has
      * already been achieved, startDirectedStream() will return an error code.

--- a/source/LibMultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/MultiSenseTypes.hh
@@ -135,7 +135,9 @@ static CRL_CONSTEXPR DataSource Source_Pps                    = (1<<26);
 
 /**
  * Class used to request that MultiSense data be sent to a 3rd-party
- * stream destination (UDP port).
+ * stream destination (UDP port), currently supported only by CRL's
+ * Monocular IP Camera.  This functionality is not supported by any of
+ * CRL's stereo sensor products.
  */
 class MULTISENSE_API DirectedStream {
 public:
@@ -697,6 +699,16 @@ public:
 
     void setHdr                     (bool  e)    { m_hdrEnabled  = e;    };
 
+    /**
+     * Set the flag to write the image configuration to flash. This will
+     * result in the camera defaulting to these settings on boot.
+     * NOTE: This should be enabled sparingly. The MultiSense flash has a
+     * limited number of writes
+     *
+     * @param e A boolean used to enable or disable writing the camera
+     *          configuration to flash
+     */
+    void setStoreSettingsInFlash    (bool e)     {m_storeSettingsInFlash = e;    };
 
     //
     // Query
@@ -853,7 +865,12 @@ public:
      */
     bool     hdrEnabled              () const { return m_hdrEnabled;  };
 
-
+    /**
+     * Query the current image configuration's flag to write parameters to flash
+     *
+     * @return The current image configuration's write to flash flag
+     */
+    bool     storeSettingsInFlash    () const { return m_storeSettingsInFlash; };
 
     //
     // Query camera calibration (read-only)
@@ -975,7 +992,8 @@ public:
     Config() : m_fps(5.0f), m_gain(1.0f),
                m_exposure(10000), m_aeEnabled(true), m_aeMax(5000000), m_aeDecay(7), m_aeThresh(0.75f),
                m_wbBlue(1.0f), m_wbRed(1.0f), m_wbEnabled(true), m_wbDecay(3), m_wbThresh(0.5f),
-               m_width(1024), m_height(544), m_disparities(128), m_cam_mode(0), m_offset(-1), m_spfStrength(0.5f), m_hdrEnabled(false),
+               m_width(1024), m_height(544), m_disparities(128), m_cam_mode(0), m_offset(-1), m_spfStrength(0.5f),
+               m_hdrEnabled(false), m_storeSettingsInFlash(false),
                m_fx(0), m_fy(0), m_cx(0), m_cy(0),
                m_tx(0), m_ty(0), m_tz(0), m_roll(0), m_pitch(0), m_yaw(0) {};
 private:
@@ -997,6 +1015,7 @@ private:
     int      m_offset;
     float    m_spfStrength;
     bool     m_hdrEnabled;
+    bool     m_storeSettingsInFlash;
 
 protected:
 
@@ -1205,6 +1224,10 @@ public:
      * to the left imager, index 1 corresponds to the right imager */
     int16_t bl_offset[2];
 
+    /** The imager vramp pair for each imager. Index 0 corresponds
+    * to the left imager, index 1 corresponds to the right imager */
+    uint8_t vramp[2];
+
 };
 
 class MULTISENSE_API TransmitDelay {
@@ -1272,7 +1295,7 @@ public:
     std::vector<uint32_t> data;
 };
 
-}; // namespace image
+} // namespace image
 
 
 
@@ -1431,7 +1454,7 @@ public:
     float cameraToSpindleFixed[4][4];
 };
 
-}; // namespace lidar
+} // namespace lidar
 
 
 
@@ -1442,8 +1465,6 @@ namespace lighting {
 static CRL_CONSTEXPR uint32_t MAX_LIGHTS     = 8;
 /** The maximum duty cycle for adjusting light intensity */
 static CRL_CONSTEXPR float    MAX_DUTY_CYCLE = 100.0;
-/** The maxmimum value of the ambient light sensor */
-static CRL_CONSTEXPR float    MAX_AMBIENT_LIGHTING = 100.0;
 
 /**
  * Class used to store a specific lighting configuration. Member of this class
@@ -1666,7 +1687,7 @@ public:
     SensorStatus() : ambientLightPercentage(100.0f) {};
 };
 
-}; // namespace lighting
+} // namespace lighting
 
 
 
@@ -1982,7 +2003,7 @@ public:
     uint32_t    rangeTableIndex;
 };
 
-}; // namespace imu
+} // namespace imu
 
 
 
@@ -2593,9 +2614,9 @@ class MULTISENSE_API ExternalCalibration {
             yaw(0.) {};
 };
 
-}; // namespace system
-}; // namespace multisense
-}; // namespace crl
+} // namespace system
+} // namespace multisense
+} // namespace crl
 
 #if defined (_MSC_VER)
 #pragma warning (pop)

--- a/source/LibMultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/MultiSenseTypes.hh
@@ -191,6 +191,8 @@ typedef uint32_t TriggerSource;
 static CRL_CONSTEXPR TriggerSource Trigger_Internal    = 0;
 /** External OPTO_RX trigger input */
 static CRL_CONSTEXPR TriggerSource Trigger_External    = 1;
+/** External OPTO_RX trigger input with Inverted Polarity */
+static CRL_CONSTEXPR TriggerSource Trigger_External_Inverted    = 2;
 
 
 
@@ -203,7 +205,7 @@ public:
      * This default implementation of the inMask member function will
      * be overridden by derived classes.
      */
-    virtual bool inMask(DataSource mask) { return true; };
+    virtual bool inMask(DataSource mask) { (void) mask; return true; };
     virtual ~HeaderBase() {};
 };
 
@@ -1363,6 +1365,7 @@ public:
 typedef void (*Callback)(const Header& header,
                          void         *userDataP);
 
+
 /**
  * Class used to store a laser calibration. Calibrations can be queried or set
  * for a specific sensor
@@ -1455,8 +1458,6 @@ public:
 };
 
 } // namespace lidar
-
-
 
 namespace lighting {
 
@@ -1721,7 +1722,7 @@ public:
 typedef void (*Callback)(const Header& header,
                          void         *userDataP);
 
-}; // namespace pps
+} // namespace pps
 
 
 
@@ -2004,9 +2005,6 @@ public:
 };
 
 } // namespace imu
-
-
-
 
 namespace system {
 

--- a/source/LibMultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/MultiSenseTypes.hh
@@ -135,9 +135,7 @@ static CRL_CONSTEXPR DataSource Source_Pps                    = (1<<26);
 
 /**
  * Class used to request that MultiSense data be sent to a 3rd-party
- * stream destination (UDP port), currently supported only by CRL's
- * Monocular IP Camera.  This functionality is not supported by any of
- * CRL's stereo sensor products.
+ * stream destination (UDP port).
  */
 class MULTISENSE_API DirectedStream {
 public:

--- a/source/LibMultiSense/details/channel.cc
+++ b/source/LibMultiSense/details/channel.cc
@@ -379,7 +379,7 @@ wire::SourceType impl::sourceApiToWire(DataSource mask)
     if (mask & Source_Pps)                    wire_mask |= wire::SOURCE_PPS;
 
     return wire_mask;
-};
+}
 
 DataSource impl::sourceWireToApi(wire::SourceType mask)
 {
@@ -403,7 +403,7 @@ DataSource impl::sourceWireToApi(wire::SourceType mask)
     if (mask & wire::SOURCE_PPS)               api_mask |= Source_Pps;
 
     return api_mask;
-};
+}
 
 uint32_t impl::hardwareApiToWire(uint32_t a)
 {
@@ -571,7 +571,7 @@ void *impl::statusThread(void *userDataP)
 
         } catch (...) {
 
-            CRL_DEBUG("unknown exception\n");
+            CRL_DEBUG_RAW("unknown exception\n");
         }
 
         //
@@ -583,7 +583,7 @@ void *impl::statusThread(void *userDataP)
     return NULL;
 }
 
-}; // namespace details
+} // namespace details
 
 Channel* Channel::Create(const std::string& address)
 {
@@ -626,5 +626,5 @@ const char *Channel::statusString(Status status)
     return "Unknown Error";
 }
 
-}; // namespace multisense
-}; // namespace crl
+} // namespace multisense
+} // namespace crl

--- a/source/LibMultiSense/details/channel.hh
+++ b/source/LibMultiSense/details/channel.hh
@@ -146,6 +146,8 @@ public:
     virtual Status getMtu                (int32_t& mtu);
     virtual Status setMtu                (int32_t mtu);
 
+    virtual Status getMotorPos           (int32_t& mtu);
+
     virtual Status getNetworkConfig      (system::NetworkConfig& c);
     virtual Status setNetworkConfig      (const system::NetworkConfig& c);
 
@@ -255,7 +257,7 @@ private:
                       const uint8_t *dataP) {
 
             if (offset <= m_lastByteOffset)
-                CRL_EXCEPTION("out-of-order or duplicate packet");
+                CRL_EXCEPTION("out-of-order or duplicate packet", "");
 
             m_assembler(m_stream, dataP, offset, bytes);
 
@@ -473,6 +475,6 @@ private:
 };
 
 
-}}}; // namespaces
+}}} // namespaces
 
 #endif // LibMultiSense_details_channel_hh

--- a/source/LibMultiSense/details/flash.cc
+++ b/source/LibMultiSense/details/flash.cc
@@ -133,7 +133,7 @@ void impl::programOrVerifyFlashRegion(std::ifstream& file,
     switch(operation) {
     case wire::SysFlashOp::OP_PROGRAM: opNameP = "programming"; break;
     case wire::SysFlashOp::OP_VERIFY:  opNameP = "verifying";   break;
-    default: 
+    default:
         CRL_EXCEPTION("unknown operation type: %d", operation);
     }
 
@@ -153,9 +153,10 @@ void impl::programOrVerifyFlashRegion(std::ifstream& file,
         Status status = waitData(op, rsp, 0.5, 4);
         if (Status_Ok != status)
             CRL_EXCEPTION("SysFlashOp (%s) failed: %d", opNameP, status);
-        else if (wire::SysFlashResponse::STATUS_SUCCESS != rsp.status)
-            CRL_EXCEPTION("%s failed @ %d/%d bytes", opNameP,
-                          file.tellg(), fileLength);
+        else if (wire::SysFlashResponse::STATUS_SUCCESS != rsp.status) {
+            unsigned int fileSize = (unsigned int)file.tellg();
+            CRL_EXCEPTION("%s failed @ %d/%d bytes", opNameP, fileSize, fileLength);
+        }
 
         //
         // Print out progress
@@ -186,11 +187,11 @@ Status impl::doFlashOp(const std::string& filename,
                        uint32_t           region)
 {
     try {
-        std::ifstream file(filename.c_str(), 
+        std::ifstream file(filename.c_str(),
                            std::ios::in | std::ios::binary);
 
-        if (!file.good()) 
-            CRL_EXCEPTION("unable to open file: \"%s\"", 
+        if (!file.good())
+            CRL_EXCEPTION("unable to open file: \"%s\"",
                           filename.c_str());
 
         if (wire::SysFlashOp::OP_PROGRAM == operation)
@@ -204,6 +205,6 @@ Status impl::doFlashOp(const std::string& filename,
     }
 
     return Status_Ok;
-}    
+}
 
 }}}; // namespaces

--- a/source/LibMultiSense/details/flash.cc
+++ b/source/LibMultiSense/details/flash.cc
@@ -87,7 +87,7 @@ void impl::eraseFlashRegion(uint32_t region)
 
         status = waitData(wire::SysFlashOp(), response);
         if (Status_Ok != status)
-            CRL_EXCEPTION("failed to request flash erase status");
+            CRL_EXCEPTION_RAW("failed to request flash erase status");
 
         //
         // IDLE means the flash has been erased
@@ -207,4 +207,4 @@ Status impl::doFlashOp(const std::string& filename,
     return Status_Ok;
 }
 
-}}}; // namespaces
+}}} // namespaces

--- a/source/LibMultiSense/details/listeners.hh
+++ b/source/LibMultiSense/details/listeners.hh
@@ -58,7 +58,7 @@ extern CRL_THREAD_LOCAL utility::BufferStream *dispatchBufferReferenceTP;
 template<class THeader, class TCallback>
 class Listener {
 public:
-    
+
     Listener(TCallback   c,
              DataSource s,
              void      *d,
@@ -69,7 +69,7 @@ public:
           m_running(false),
           m_queue(m),
           m_dispatchThreadP(NULL) {
-        
+
         m_running         = true;
         m_dispatchThreadP = new utility::Thread(dispatchThread, this);
     };
@@ -173,9 +173,9 @@ private:
 #else
     static void *dispatchThread(void *argumentP) {
 #endif
-        
+
         Listener<THeader,TCallback> *selfP = reinterpret_cast< Listener<THeader,TCallback> * >(argumentP);
-    
+
         while(selfP->m_running) {
             try {
                 Dispatch d;
@@ -186,7 +186,7 @@ private:
                 CRL_DEBUG("exception invoking image callback: %s\n",
                           e.what());
             } catch ( ... ) {
-                CRL_DEBUG("unknown exception invoking image callback\n");
+                CRL_DEBUG_RAW("unknown exception invoking image callback\n");
             }
         };
 
@@ -202,7 +202,7 @@ private:
 
     //
     // Dispatch mechanism
-    
+
     volatile bool                m_running;
     utility::WaitQueue<Dispatch> m_queue;
     utility::Thread             *m_dispatchThreadP;
@@ -213,9 +213,9 @@ typedef Listener<lidar::Header, lidar::Callback> LidarListener;
 typedef Listener<pps::Header,   pps::Callback>   PpsListener;
 typedef Listener<imu::Header,   imu::Callback>   ImuListener;
 
-}; // namespace details
-}; // namespace multisense
-}; // namespace crl
+} // namespace details
+} // namespace multisense
+} // namespace crl
 
 
 #endif //  LibMultiSense_impl_listeners

--- a/source/LibMultiSense/details/public.cc
+++ b/source/LibMultiSense/details/public.cc
@@ -66,6 +66,9 @@
 #include "details/wire/LedGetSensorStatusMessage.h"
 #include "details/wire/LedSensorStatusMessage.h"
 
+#include "details/wire/LidarPollMotorMessage.h"
+#include "details/wire/PollMotorInfoMessage.h"
+
 #include "details/wire/SysMtuMessage.h"
 #include "details/wire/SysGetMtuMessage.h"
 #include "details/wire/SysFlashOpMessage.h"
@@ -324,7 +327,7 @@ void *impl::reserveCallbackBuffer()
 
         } catch (...) {
 
-            CRL_DEBUG("unknown exception\n");
+            CRL_DEBUG_RAW("unknown exception\n");
         }
     }
 
@@ -349,7 +352,7 @@ Status impl::releaseCallbackBuffer(void *referenceP)
 
         } catch (...) {
 
-            CRL_DEBUG("unknown exception\n");
+            CRL_DEBUG_RAW("unknown exception\n");
             return Status_Exception;
         }
     }
@@ -524,6 +527,11 @@ Status impl::setTriggerSource(TriggerSource s)
     case Trigger_External:
 
         wireSource = wire::CamSetTriggerSource::SOURCE_EXTERNAL;
+        break;
+
+    case Trigger_External_Inverted:
+
+        wireSource = wire::CamSetTriggerSource::SOURCE_EXTERNAL_INVERTED;
         break;
 
     default:
@@ -930,6 +938,17 @@ Status impl::getMtu(int32_t& mtu)
     return status;
 }
 
+Status impl::getMotorPos(int32_t& pos)
+{
+    wire::MotorPoll resp;
+
+    Status status = waitData(wire::LidarPollMotor(), resp);
+    if (Status_Ok == status)
+    	pos = resp.angleStart;
+
+    return status;
+}
+
 //
 // Set/get the network configuration
 
@@ -1302,4 +1321,4 @@ Status impl::getLocalUdpPort(uint16_t& port)
     port = m_serverSocketPort;
     return Status_Ok;
 }
-}}}; // namespaces
+}}} // namespaces

--- a/source/LibMultiSense/details/public.cc
+++ b/source/LibMultiSense/details/public.cc
@@ -113,15 +113,15 @@ CRL_THREAD_LOCAL utility::BufferStream *dispatchBufferReferenceTP = NULL;
 //
 // Adds a new image listener
 
-Status impl::addIsolatedCallback(image::Callback callback, 
+Status impl::addIsolatedCallback(image::Callback callback,
                                  DataSource     imageSourceMask,
                                  void           *userDataP)
 {
     try {
 
         utility::ScopedLock lock(m_dispatchLock);
-        m_imageListeners.push_back(new ImageListener(callback, 
-                                                     imageSourceMask, 
+        m_imageListeners.push_back(new ImageListener(callback,
+                                                     imageSourceMask,
                                                      userDataP,
                                                      MAX_USER_IMAGE_QUEUE_SIZE));
 
@@ -135,13 +135,13 @@ Status impl::addIsolatedCallback(image::Callback callback,
 //
 // Adds a new laser listener
 
-Status impl::addIsolatedCallback(lidar::Callback callback, 
+Status impl::addIsolatedCallback(lidar::Callback callback,
                                  void           *userDataP)
 {
     try {
 
         utility::ScopedLock lock(m_dispatchLock);
-        m_lidarListeners.push_back(new LidarListener(callback, 
+        m_lidarListeners.push_back(new LidarListener(callback,
                                                      0,
                                                      userDataP,
                                                      MAX_USER_LASER_QUEUE_SIZE));
@@ -156,13 +156,13 @@ Status impl::addIsolatedCallback(lidar::Callback callback,
 //
 // Adds a new PPS listener
 
-Status impl::addIsolatedCallback(pps::Callback callback, 
+Status impl::addIsolatedCallback(pps::Callback callback,
                                  void         *userDataP)
 {
     try {
 
         utility::ScopedLock lock(m_dispatchLock);
-        m_ppsListeners.push_back(new PpsListener(callback, 
+        m_ppsListeners.push_back(new PpsListener(callback,
                                                  0,
                                                  userDataP,
                                                  MAX_USER_PPS_QUEUE_SIZE));
@@ -177,13 +177,13 @@ Status impl::addIsolatedCallback(pps::Callback callback,
 //
 // Adds a new IMU listener
 
-Status impl::addIsolatedCallback(imu::Callback callback, 
+Status impl::addIsolatedCallback(imu::Callback callback,
                                  void         *userDataP)
 {
     try {
 
         utility::ScopedLock lock(m_dispatchLock);
-        m_imuListeners.push_back(new ImuListener(callback, 
+        m_imuListeners.push_back(new ImuListener(callback,
                                                  0,
                                                  userDataP,
                                                  MAX_USER_IMU_QUEUE_SIZE));
@@ -207,7 +207,7 @@ Status impl::removeIsolatedCallback(image::Callback callback)
         for(it  = m_imageListeners.begin();
             it != m_imageListeners.end();
             it ++) {
-        
+
             if ((*it)->callback() == callback) {
                 delete *it;
                 m_imageListeners.erase(it);
@@ -235,7 +235,7 @@ Status impl::removeIsolatedCallback(lidar::Callback callback)
         for(it  = m_lidarListeners.begin();
             it != m_lidarListeners.end();
             it ++) {
-        
+
             if ((*it)->callback() == callback) {
                 delete *it;
                 m_lidarListeners.erase(it);
@@ -263,7 +263,7 @@ Status impl::removeIsolatedCallback(pps::Callback callback)
         for(it  = m_ppsListeners.begin();
             it != m_ppsListeners.end();
             it ++) {
-        
+
             if ((*it)->callback() == callback) {
                 delete *it;
                 m_ppsListeners.erase(it);
@@ -291,7 +291,7 @@ Status impl::removeIsolatedCallback(imu::Callback callback)
         for(it  = m_imuListeners.begin();
             it != m_imuListeners.end();
             it ++) {
-        
+
             if ((*it)->callback() == callback) {
                 delete *it;
                 m_imuListeners.erase(it);
@@ -317,13 +317,13 @@ void *impl::reserveCallbackBuffer()
         try {
 
             return reinterpret_cast<void*>(new utility::BufferStream(*dispatchBufferReferenceTP));
-            
+
         } catch (const std::exception& e) {
-            
+
             CRL_DEBUG("exception: %s\n", e.what());
-            
+
         } catch (...) {
-            
+
             CRL_DEBUG("unknown exception\n");
         }
     }
@@ -343,12 +343,12 @@ Status impl::releaseCallbackBuffer(void *referenceP)
             return Status_Ok;
 
         } catch (const std::exception& e) {
-            
+
             CRL_DEBUG("exception: %s\n", e.what());
             return Status_Exception;
-            
+
         } catch (...) {
-            
+
             CRL_DEBUG("unknown exception\n");
             return Status_Exception;
         }
@@ -364,12 +364,12 @@ Status impl::getImageHistogram(int64_t           frameId,
                                image::Histogram& histogram)
 {
     try {
-        
+
         utility::ScopedLock lock(m_imageMetaCache.mutex());
 
         const wire::ImageMeta *metaP = m_imageMetaCache.find_nolock(frameId);
         if (NULL == metaP) {
-            CRL_DEBUG("no meta cached for frameId %ld", 
+            CRL_DEBUG("no meta cached for frameId %ld",
                       static_cast<long int>(frameId));
             return Status_Failed;
         }
@@ -492,7 +492,7 @@ Status impl::getDirectedStreams(std::vector<DirectedStream>& streams)
     status = waitData(wire::SysGetDirectedStreams(), rsp);
     if (Status_Ok != status)
         return status;
-    
+
     std::vector<wire::DirectedStream>::const_iterator it = rsp.streams.begin();
     for(; it != rsp.streams.end(); ++it)
         streams.push_back(DirectedStream((*it).mask,
@@ -516,7 +516,7 @@ Status impl::setTriggerSource(TriggerSource s)
     uint32_t wireSource;
 
     switch(s) {
-    case Trigger_Internal: 
+    case Trigger_Internal:
 
         wireSource = wire::CamSetTriggerSource::SOURCE_INTERNAL;
         break;
@@ -553,7 +553,7 @@ Status impl::getLightingConfig(lighting::Config& c)
     status = waitData(wire::LedGetStatus(), data);
     if (Status_Ok != status)
         return status;
-        
+
     for(uint32_t i=0; i<lighting::MAX_LIGHTS; i++) {
         float duty=0.0f;
         if ((1<<i) & data.available)
@@ -572,7 +572,7 @@ Status impl::setLightingConfig(const lighting::Config& c)
 
     msg.flash = c.getFlash() ? 1 : 0;
     for(uint32_t i=0; i<lighting::MAX_LIGHTS; i++) {
-      
+
         float duty = c.getDutyCycle(i);
         if (duty >= 0.0f) {  // less than zero == not set
             msg.mask |= (1<<i);
@@ -650,14 +650,14 @@ Status impl::getImageConfig(image::Config& config)
                     float tx, float ty, float tz,
                     float r,  float p,  float w) {
             m_fx = fx; m_fy = fy; m_cx = cx; m_cy = cy;
-            m_tx = tx; m_ty = ty; m_tz = tz; 
+            m_tx = tx; m_ty = ty; m_tz = tz;
             m_roll = r; m_pitch = p; m_yaw = w;
         };
     };
-      
+
     // what is the proper c++ cast for this?
     ConfigAccess& a = *((ConfigAccess *) &config);
-    
+
     a.setResolution(d.width, d.height);
     if (-1 == d.disparities) { // pre v2.3 firmware
         if (1024 == d.width)   // TODO: check for monocular
@@ -668,13 +668,13 @@ Status impl::getImageConfig(image::Config& config)
     a.setDisparities(d.disparities);
     a.setFps(d.framesPerSecond);
     a.setGain(d.gain);
-    
+
     a.setExposure(d.exposure);
     a.setAutoExposure(d.autoExposure != 0);
     a.setAutoExposureMax(d.autoExposureMax);
     a.setAutoExposureDecay(d.autoExposureDecay);
     a.setAutoExposureThresh(d.autoExposureThresh);
-    
+
     a.setWhiteBalance(d.whiteBalanceRed, d.whiteBalanceBlue);
     a.setAutoWhiteBalance(d.autoWhiteBalance != 0);
     a.setAutoWhiteBalanceDecay(d.autoWhiteBalanceDecay);
@@ -682,10 +682,10 @@ Status impl::getImageConfig(image::Config& config)
     a.setStereoPostFilterStrength(d.stereoPostFilterStrength);
     a.setHdr(d.hdrEnabled);
 
-    a.setCal(d.fx, d.fy, d.cx, d.cy, 
+    a.setCal(d.fx, d.fy, d.cx, d.cy,
              d.tx, d.ty, d.tz,
              d.roll, d.pitch, d.yaw);
-    
+
     return Status_Ok;
 }
 
@@ -699,7 +699,7 @@ Status impl::setImageConfig(const image::Config& c)
 {
     Status status;
 
-    status = waitAck(wire::CamSetResolution(c.width(), 
+    status = waitAck(wire::CamSetResolution(c.width(),
                                             c.height(),
                                             c.disparities(),
                                             c.camMode(),
@@ -711,7 +711,7 @@ Status impl::setImageConfig(const image::Config& c)
 
     cmd.framesPerSecond = c.fps();
     cmd.gain            = c.gain();
-    
+
     cmd.exposure           = c.exposure();
     cmd.autoExposure       = c.autoExposure() ? 1 : 0;
     cmd.autoExposureMax    = c.autoExposureMax();
@@ -725,6 +725,7 @@ Status impl::setImageConfig(const image::Config& c)
     cmd.autoWhiteBalanceThresh   = c.autoWhiteBalanceThresh();
     cmd.stereoPostFilterStrength = c.stereoPostFilterStrength();
     cmd.hdrEnabled               = c.hdrEnabled();
+    cmd.storeSettingsInFlash     = c.storeSettingsInFlash();
 
     return waitAck(cmd);
 }
@@ -785,6 +786,7 @@ Status impl::getSensorCalibration(image::SensorCalibration& c)
         return status;
     CPY_ARRAY_1(c.adc_gain, d.adc_gain, 2);
     CPY_ARRAY_1(c.bl_offset, d.bl_offset, 2);
+    CPY_ARRAY_1(c.vramp, d.vramp, 2);
 
     return Status_Ok;
 }
@@ -798,6 +800,7 @@ Status impl::setSensorCalibration(const image::SensorCalibration& c)
 
     CPY_ARRAY_1(d.adc_gain, c.adc_gain, 2);
     CPY_ARRAY_1(d.bl_offset, c.bl_offset, 2);
+    CPY_ARRAY_1(d.vramp, c.vramp, 2);
 
     return waitAck(d);
 }
@@ -873,7 +876,7 @@ Status impl::getDeviceModes(std::vector<system::DeviceMode>& modes)
     modes.resize(d.modes.size());
     for(uint32_t i=0; i<d.modes.size(); i++) {
 
-        system::DeviceMode&     a = modes[i]; 
+        system::DeviceMode&     a = modes[i];
         const wire::DeviceMode& w = d.modes[i];
 
         a.width                = w.width;
@@ -881,10 +884,10 @@ Status impl::getDeviceModes(std::vector<system::DeviceMode>& modes)
         a.supportedDataSources = sourceWireToApi(w.supportedDataSources);
         if (m_sensorVersion.firmwareVersion >= 0x0203)
             a.disparities = w.disparities;
-        else 
+        else
             a.disparities = (a.width == 1024) ? 128 : 0;
     }
-                        
+
     return Status_Ok;
 }
 
@@ -976,7 +979,7 @@ Status impl::getDeviceInfo(system::DeviceInfo& info)
 
         info.pcbs.push_back(pcb);
     }
-        
+
     info.imagerName              = w.imagerName;
     info.imagerType              = imagerWireToApi(w.imagerType);
     info.imagerWidth             = w.imagerWidth;
@@ -1078,13 +1081,13 @@ Status impl::setDeviceInfo(const std::string& key,
     w.buildDate        = info.buildDate;
     w.serialNumber     = info.serialNumber;
     w.hardwareRevision = hardwareApiToWire(info.hardwareRevision);
-    w.numberOfPcbs     = std::min((uint32_t) info.pcbs.size(), 
+    w.numberOfPcbs     = std::min((uint32_t) info.pcbs.size(),
                                   (uint32_t) wire::SysDeviceInfo::MAX_PCBS);
     for(uint32_t i=0; i<w.numberOfPcbs; i++) {
         w.pcbs[i].name     = info.pcbs[i].name;
         w.pcbs[i].revision = info.pcbs[i].revision;
     }
-        
+
     w.imagerName              = info.imagerName;
     w.imagerType              = imagerApiToWire(info.imagerType);
     w.imagerWidth             = info.imagerWidth;
@@ -1169,7 +1172,7 @@ Status impl::getImuInfo(uint32_t& maxSamplesPerMessage,
         info[i].name   = d.name;
         info[i].device = d.device;
         info[i].units  = d.units;
-        
+
         info[i].rates.resize(d.rates.size());
         for(uint32_t j=0; j<d.rates.size(); j++) {
             info[i].rates[j].sampleRate      = d.rates[j].sampleRate;
@@ -1245,7 +1248,7 @@ Status impl::getLargeBufferDetails(uint32_t& bufferCount,
 {
     bufferCount = RX_POOL_LARGE_BUFFER_COUNT;
     bufferSize  = RX_POOL_LARGE_BUFFER_SIZE;
-    
+
     return Status_Ok;
 }
 
@@ -1257,17 +1260,17 @@ Status impl::setLargeBuffers(const std::vector<uint8_t*>& buffers,
 {
     if (buffers.size() < RX_POOL_LARGE_BUFFER_COUNT)
         CRL_DEBUG("WARNING: supplying less than recommended number of large buffers: %ld/%ld\n",
-                  static_cast<long int>(buffers.size()), 
+                  static_cast<long int>(buffers.size()),
                   static_cast<long int>(RX_POOL_LARGE_BUFFER_COUNT));
     if (bufferSize < RX_POOL_LARGE_BUFFER_SIZE)
         CRL_DEBUG("WARNING: supplying smaller than recommended large buffers: %ld/%ld bytes\n",
-                  static_cast<long int>(bufferSize), 
+                  static_cast<long int>(bufferSize),
                   static_cast<long int>(RX_POOL_LARGE_BUFFER_SIZE));
 
     try {
 
         utility::ScopedLock lock(m_rxLock); // halt potential pool traversal
-        
+
         //
         // Deletion is safe even if the buffer is in use elsewhere
         // (BufferStream is reference counted.)

--- a/source/LibMultiSense/details/query.hh
+++ b/source/LibMultiSense/details/query.hh
@@ -55,7 +55,7 @@ template<class T> void impl::publish(const T& message)
     //
     // An output stream to serialize the data
 
-    utility::BufferStreamWriter stream(m_sensorMtu - 
+    utility::BufferStreamWriter stream(m_sensorMtu -
                                        wire::COMBINED_HEADER_LENGTH);
 
     //
@@ -65,10 +65,10 @@ template<class T> void impl::publish(const T& message)
 
     //
     // Set the ID and version
-    
+
     stream & id;
     stream & version;
-    
+
     //
     // Add the message payload. We cast away const here because
     // we have a single serialize() for both directions, and cannot
@@ -86,7 +86,7 @@ template<class T> void impl::publish(const T& message)
 // Send a message, wait for a particular repsonse, re-trying if
 // necessary
 
-template <class T> Status impl::waitAck(const T&      msg, 
+template <class T> Status impl::waitAck(const T&      msg,
                                         wire::IdType  ackId,
                                         const double& timeout,
                                         int32_t       attempts)
@@ -97,7 +97,7 @@ template <class T> Status impl::waitAck(const T&      msg,
         while(attempts-- > 0) {
 
             publish(msg);
-            
+
             Status status;
             if (false == ack.wait(status, timeout))
                 continue;
@@ -114,7 +114,7 @@ template <class T> Status impl::waitAck(const T&      msg,
 }
 
 //
-// Send a message (with retry), expecting data message, 
+// Send a message (with retry), expecting data message,
 // extract data payload for user
 
 template <class T, class U> Status impl::waitData(const T&      command,
@@ -142,14 +142,14 @@ template <class T, class U> Status impl::waitData(const T&      command,
         Status commandStatus;
         if (false == commandAck.wait(commandStatus, 0.0))
             commandStatus = Status_TimedOut;
-    
+
         //
         // If we did not receive the data message, return the response from
-        // the command code instead, unless there was an exception or the 
+        // the command code instead, unless there was an exception or the
         // command ack'd OK.
 
         if (Status_Ok != dataStatus) {
-            if (Status_Exception == dataStatus ||   // exception 
+            if (Status_Exception == dataStatus ||   // exception
                 Status_Ok        == commandStatus)  // data payload timeout or MTU error
                 return dataStatus;
             else
@@ -158,15 +158,15 @@ template <class T, class U> Status impl::waitData(const T&      command,
 
         //
         // We have received the data message, extract it for the user.
-        
+
         return m_messages.extract(data);
-        
+
     } catch (const std::exception& e) {
         CRL_DEBUG("exception: %s\n", e.what());
         return Status_Exception;
     }
 }
 
-}}}; // namespaces
+}}} // namespaces
 
 #endif // _LibMultiSense_details_publish_hh

--- a/source/LibMultiSense/details/signal.hh
+++ b/source/LibMultiSense/details/signal.hh
@@ -75,7 +75,7 @@ private:
     typedef utility::WaitVar<Status>        Signal;
     typedef std::map<wire::IdType, Signal*> Map;
 
-    void insert(wire::IdType type, 
+    void insert(wire::IdType type,
 		Signal      *signalP) {
         utility::ScopedLock lock(m_lock);
 
@@ -83,7 +83,7 @@ private:
 
         //
         // Hmm.. this will prohibit multiple threads
-        // simultaneously commanding the sensor with this 
+        // simultaneously commanding the sensor with this
 	// message ID.
 
         if (m_map.end() != it)
@@ -122,7 +122,7 @@ public:
 	m_map.remove(m_id);
     };
 
-    bool wait(Status&       status, 
+    bool wait(Status&       status,
 	      const double& timeout) {
 	return m_signal.timedWait(status, timeout);
     };
@@ -134,9 +134,9 @@ private:
     MessageWatch::Signal m_signal;
 };
 
-}; // namespace details
-}; // namespace multisense
-}; // namespace crl
+} // namespace details
+} // namespace multisense
+} // namespace crl
 
 
 #endif //  LibMultiSense_details_signal_hh

--- a/source/LibMultiSense/details/storage.hh
+++ b/source/LibMultiSense/details/storage.hh
@@ -45,7 +45,7 @@
 namespace crl {
 namespace multisense {
 namespace details {
-    
+
     //
     // A message storage interface
     //
@@ -64,7 +64,7 @@ namespace details {
             }
 
             m_map[MSG_ID(T::ID)] = Holder::Create<T>(msg);
-        };
+        }
 
         template<class T> Status extract(T& msg) {
             utility::ScopedLock lock(m_lock);
@@ -77,32 +77,32 @@ namespace details {
             m_map.erase(it);
 
             return Status_Ok;
-        };
-        
+        }
+
     private:
 
         class Holder {
         public:
-       
+
             Holder(void *r=NULL) : m_refP(r) {};
-            
+
             template<class T> static Holder Create(const T& msg) {
                 return Holder(reinterpret_cast<void *>(new T(msg)));
-            };
-      
+            }
+
             template<class T> void destroy() {
                 if (NULL == m_refP)
-                    CRL_EXCEPTION("destroying NULL reference");
+                    CRL_EXCEPTION("destroying NULL reference", "");
                 delete reinterpret_cast<T*>(m_refP);
-            };
-        
+            }
+
             template<class T> void extract(T& msg) {
                 if (NULL == m_refP)
-                    CRL_EXCEPTION("extracting NULL reference");
+                    CRL_EXCEPTION("extracting NULL reference", "");
                 msg = *(reinterpret_cast<T*>(m_refP));
                 destroy<T>();
-            };
-            
+            }
+
         private:
             void *m_refP;
         };
@@ -124,14 +124,14 @@ namespace details {
     // DATA objects are assumed to be allocated on the heap, and memory management
     // of the object is delegated here upon insert().
     //
-    // For *_nolock() variations, lock-management must be 
+    // For *_nolock() variations, lock-management must be
     // done by the user.
 
     template<class KEY, class DATA>
     class DepthCache {
     public:
-        
-        DepthCache(std::size_t depth, KEY min) : 
+
+        DepthCache(std::size_t depth, KEY min) :
             m_depth(depth),
             m_minimum(min) {};
 
@@ -145,8 +145,8 @@ namespace details {
             }
         };
 
-        utility::Mutex& mutex() { 
-            return m_lock; 
+        utility::Mutex& mutex() {
+            return m_lock;
         };
 
         DATA* find_nolock(KEY key) {
@@ -219,6 +219,6 @@ namespace details {
         utility::Mutex    m_lock;
     };
 
-}}}; // namespaces
+}}} // namespaces
 
 #endif // LibMultiSense_details_storage_hh

--- a/source/LibMultiSense/details/utility/BufferStream.hh
+++ b/source/LibMultiSense/details/utility/BufferStream.hh
@@ -77,10 +77,14 @@ public:
 #endif // SENSORPOD_FIRMWARE
 
     virtual void read (void *bufferP, std::size_t length) {
-        CRL_EXCEPTION("not implemented");
+        (void) bufferP;
+        (void) length;
+        CRL_EXCEPTION("not implemented", "");
     };
     virtual void write(const void *bufferP, std::size_t length) {
-        CRL_EXCEPTION("not implemented");
+        (void) bufferP;
+        (void) length;
+        CRL_EXCEPTION("not implemented", "");
     };
 
     //
@@ -185,12 +189,12 @@ public:
 
         memcpy(bufferP, &(m_bufferP[m_tell]), length);
         m_tell += length;
-    };
+    }
 
     template <typename T> BufferStreamReader& operator&(T &value) {
         this->read(&value, sizeof(T));
         return *this;
-    };
+    }
 
     template <typename T> BufferStreamReader& operator&(std::vector<T>& v) {
         uint16_t version;
@@ -217,7 +221,7 @@ public:
             value = std::string(buffer);
         }
         return *this;
-    };
+    }
 
     BufferStreamReader& operator&(TimeStamp& value) {
         uint32_t seconds;
@@ -229,7 +233,7 @@ public:
         value = seconds + 1e-6 * microseconds;
 
         return *this;
-    };
+    }
 };
 
 //
@@ -257,7 +261,7 @@ public:
     template <typename T> BufferStreamWriter& operator&(const T& value) {
         this->write(&value, sizeof(T));
         return *this;
-    };
+    }
 
     template <typename T> BufferStreamWriter& operator&(const std::vector<T>& v) {
         uint16_t version = T::VERSION;

--- a/source/LibMultiSense/details/utility/Exception.hh
+++ b/source/LibMultiSense/details/utility/Exception.hh
@@ -74,6 +74,12 @@
                                                            CRL_PRETTY_FUNCTION,##__VA_ARGS__); \
     } while(0)
 
+#define CRL_EXCEPTION_RAW(fmt)                                         \
+    do {                                                                \
+        throw crl::multisense::details::utility::Exception("%s(%d): %s: " fmt,CRL_FILENAME,__LINE__, \
+                                                           CRL_PRETTY_FUNCTION); \
+    } while(0)
+
 #define CRL_DEBUG(fmt, ...)                                             \
     do {                                                                \
         double now = crl::multisense::details::utility::TimeStamp::getCurrentTime(); \
@@ -81,6 +87,12 @@
                 CRL_PRETTY_FUNCTION,##__VA_ARGS__);                     \
     } while(0)
 
+#define CRL_DEBUG_RAW(fmt)                                             \
+    do {                                                                \
+        double now = crl::multisense::details::utility::TimeStamp::getCurrentTime(); \
+        CRL_DEBUG_REDIRECTION "[%.3f] %s(%d): %s: " fmt,now,CRL_FILENAME,__LINE__, \
+                CRL_PRETTY_FUNCTION);                     \
+    } while(0)
 
 namespace crl {
 namespace multisense {

--- a/source/LibMultiSense/details/utility/Portability.hh
+++ b/source/LibMultiSense/details/utility/Portability.hh
@@ -6,25 +6,36 @@
  *
  * Copyright 2014
  * Carnegie Robotics, LLC
- * Ten 40th Street, Pittsburgh, PA 15201
+ * 4501 Hatfield Street, Pittsburgh, PA 15201
  * http://www.carnegierobotics.com
  *
- * This software is free: you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation,
- * version 3 of the License.
+ * All rights reserved.
  *
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Carnegie Robotics, LLC nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this software.  If not, see <http://www.gnu.org/licenses/>.
- *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL CARNEGIE ROBOTICS, LLC BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * Significant history (date, user, job code, action):
  *   2014-08-07, dlr@carnegierobotics.com, IRAD, Created file.
+ *   2019-06-07, qtorgerson@carnegierobotics.com, converted license to BSD.
  **/
 
 #ifndef CRL_MULTISENSE_DETAILS_PORTABILITY_HH

--- a/source/LibMultiSense/details/utility/Thread.hh
+++ b/source/LibMultiSense/details/utility/Thread.hh
@@ -36,6 +36,8 @@
 
 #if defined(WIN32)
 #include "win32/Thread.hh"
+#elif __APPLE__
+#include "macos/Thread.hh"
 #else
 #include "linux/Thread.hh"
 #endif

--- a/source/LibMultiSense/details/utility/macos/Thread.hh
+++ b/source/LibMultiSense/details/utility/macos/Thread.hh
@@ -1,0 +1,462 @@
+/**
+ * @file LibMultiSense/details/utility/macos/Thread.hh
+ *
+ * Copyright 2017
+ * Carnegie Robotics, LLC
+ * 4501 Hatfield Street, Pittsburgh, PA 15201
+ * http://www.carnegierobotics.com
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Carnegie Robotics, LLC nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL CARNEGIE ROBOTICS, LLC BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Significant history (date, user, job code, action):
+ *   2017-03-17, osterwood@carnegierobotics.com, 1048, Created file.
+ **/
+
+#ifndef CRL_MULTISENSE_THREAD_HH
+#define CRL_MULTISENSE_THREAD_HH
+
+#include <stdint.h>
+#include <errno.h>
+#include <string.h>
+#include <pthread.h>
+
+#include <mach/mach_init.h>
+#include <mach/task.h>
+#include <mach/semaphore.h>
+
+#include <vector>
+#include <deque>
+
+#include "details/utility/Portability.hh"
+
+#include "../Exception.hh"
+
+namespace crl {
+namespace multisense {
+namespace details {
+namespace utility {
+
+// #define sem_t                         semaphore_t
+// #define sem_init(SEM,UNUSED,VALUE)    semaphore_create(current_task(), (SEM), SYNC_POLICY_FIFO, (VALUE))
+// #define sem_destroy(SEM)              semaphore_destroy(current_task(), *(SEM))
+// #define sem_wait(SEM)                 semaphore_wait(*(SEM))
+// #define sem_post(SEM)                 semaphore_signal(*(SEM))
+
+//
+// Forward declarations.
+
+class ScopedLock;
+
+//
+// A simple class to wrap pthread creation and joining
+
+class Thread {
+public:
+
+    static CRL_CONSTEXPR uint32_t FLAGS_DETACH = (1 << 0);
+
+    Thread(void    *(*functionP)(void *),
+           void    *contextP=NULL,
+           uint32_t flags=0,
+           int32_t  scheduler=-1,
+           int32_t  priority=0) : m_flags(flags) {
+
+        pthread_attr_t tattr;
+        pthread_attr_init(&tattr);
+
+        //
+        // -1 means the user wants default scheduling behavior
+
+        if (-1 != scheduler) {
+            struct sched_param sattr = {0};
+
+            //
+            // Set our scheduling policy
+
+            if (0 != pthread_attr_setschedpolicy(&tattr, scheduler))
+                CRL_EXCEPTION("pthread_attr_setschedpolicy(scheduler=%d) failed: %s",
+                                   scheduler, strerror(errno));
+            //
+            // Set our scheduling parameters (just priority)
+
+            sattr.sched_priority = priority;
+            if (0 != pthread_attr_setschedparam(&tattr, &sattr))
+                CRL_EXCEPTION("pthread_attr_setschedparam(pri=%d) failed: %s",
+                                   priority, strerror(errno));
+            //
+            // We must set EXPLICIT_SCHED so the parent's scheduler is not
+            // automatically inherited
+
+            if (0 != pthread_attr_setinheritsched(&tattr, PTHREAD_EXPLICIT_SCHED))
+                CRL_EXCEPTION("pthread_attr_setinheritsched(explicit) failed: %s",
+                                   strerror(errno));
+        }
+
+        //
+        // Create detached, if asked to do so
+
+        if (FLAGS_DETACH & m_flags &&
+            0 != pthread_attr_setdetachstate(&tattr, PTHREAD_CREATE_DETACHED))
+            CRL_EXCEPTION("pthread_attr_setdetachstate() failed: %s", strerror(errno));
+
+        //
+        // Finally, create the thread
+
+        if (0 != pthread_create(&m_id, &tattr, functionP, contextP))
+            CRL_EXCEPTION("pthread_create() failed: %s", strerror(errno));
+    };
+
+    ~Thread() {
+        if (!(m_flags & FLAGS_DETACH) &&
+            0 != pthread_join(m_id, NULL))
+            CRL_DEBUG("pthread_join() failed: %s\n", strerror(errno));
+    };
+
+private:
+
+    uint32_t  m_flags;
+    pthread_t m_id;
+};
+
+//
+// A simple mutex class
+
+class Mutex {
+public:
+    friend class ScopedLock;
+
+    Mutex() : m_mutex() {
+        if (0 != pthread_mutex_init(&m_mutex, NULL))
+            CRL_EXCEPTION("pthread_mutex_init() failed: %s",
+                          strerror(errno));
+    }
+
+    ~Mutex() {
+        pthread_mutex_destroy(&m_mutex);
+    };
+
+private:
+    pthread_mutex_t m_mutex;
+};
+
+//
+// A simple scoped lock class
+
+class ScopedLock
+{
+public:
+
+    ScopedLock(Mutex& mutex) {
+        this->lock(&mutex.m_mutex);
+    };
+
+    ScopedLock(pthread_mutex_t *lockP) {
+        this->lock(lockP);
+    };
+
+    ScopedLock(pthread_mutex_t& lock) {
+        this->lock(&lock);
+    };
+
+    ~ScopedLock() {
+        pthread_mutex_unlock(m_lockP);
+    };
+
+private:
+
+    void lock(pthread_mutex_t *lockP) {
+        m_lockP = lockP;
+        pthread_mutex_lock(m_lockP);
+    };
+
+    pthread_mutex_t *m_lockP;
+};
+
+// A futex-based semaphore.
+//
+// This implementation does not work across processes.
+
+class Semaphore {
+public:
+
+    //
+    // Wait for a post (decrement). If thread contention,
+    // we may wake up, but be unable to snatch
+    // the bait.. hence the while loop.
+
+    bool wait() {
+        do {
+            if (0 == wait_())
+                return true;
+        } while (1);
+    };
+
+    //
+    // Wait for a post, retrying until timeout
+
+    bool timedWait(const double& timeout) {
+
+        if (timeout < 0.0)
+            CRL_EXCEPTION("invalid timeout: %f", timeout);
+
+        struct timespec ts;
+        ts.tv_sec  = timeout;
+        ts.tv_nsec = (timeout - ts.tv_sec) * 1e9;
+
+        do {
+            int32_t ret = wait_(&ts);
+
+            if (0 == ret)
+                return true;
+            else if (ETIMEDOUT == ret)
+                return false;
+
+        } while (1);
+    };
+
+    //
+    // Post to the semaphore (increment.) Here we
+    // signal the futex to wake up any waiters.
+
+    bool post() {
+
+
+        // Limit the posts, if asked to do so
+
+        if (m_maximum > 0 && m_avail >= static_cast<int>(m_maximum))
+            return false;
+
+        // const int32_t nval = __sync_add_and_fetch(&m_avail, 1);
+        __sync_add_and_fetch(&m_avail, 1);
+
+        if (m_waiters > 0) {
+            // syscall(__NR_futex, &m_avail, FUTEX_WAKE, nval, NULL, 0, 0);
+            // semaphore_signal(m_sem);
+            semaphore_signal_all(m_sem);
+        }
+
+        return true;
+    };
+
+    //
+    // Decrement the semaphore to zero in one-shot.. may
+    // fail with thread contention, returns true if
+    // successful
+
+    bool clear() {
+        int32_t val = m_avail;
+        if (val > 0)
+            return __sync_bool_compare_and_swap(&m_avail, val, 0);
+        return true;
+    };
+
+    int32_t count    () { return m_avail;   };
+    int32_t waiters  () { return m_waiters; };
+    bool    decrement() { return wait();    };
+    bool    increment() { return post();    };
+
+    Semaphore(std::size_t max=0) :
+        m_maximum(max),
+        m_avail(0),
+        m_waiters(0)
+        {
+            semaphore_create(mach_task_self(), &m_sem, SYNC_POLICY_FIFO, 1);
+        };
+
+    ~Semaphore() {
+        semaphore_destroy(mach_task_self(), m_sem);
+    };
+
+private:
+
+    //
+    // This actually does the synchronized decrement if possible, and goes
+    // to sleep on the futex if not.
+
+    inline int32_t wait_(const struct timespec *tsP=NULL) {
+
+        //
+        // Can we decrement the requested amount? If so, return success
+
+        const int32_t val = m_avail;
+        if (val >= 1 && __sync_bool_compare_and_swap(&m_avail, val, val - 1))
+            return 0;
+
+        //
+        // We must go to sleep until someone increments. Also keep track of
+        // how many threads are waiting on this futex.
+
+        __sync_fetch_and_add(&m_waiters, 1);
+        // const int32_t ret = syscall(__NR_futex, &m_avail, FUTEX_WAIT, val, tsP, 0, 0);
+        const int32_t ret = semaphore_wait(m_sem);
+        __sync_fetch_and_sub(&m_waiters, 1);
+
+        //
+        // If we just woke up on the futex, then return EAGAIN, so we
+        // can come back in here and attempt a synchronized decrement again.
+
+        if (ETIMEDOUT == ret || -1 == ret) // hmmm.. timeouts are returning -1
+            return ETIMEDOUT;
+        else
+            return EAGAIN;
+    };
+
+    typedef int32_t aligned_int32_t __attribute__((aligned (4))); // unnecessary ?
+
+    const std::size_t m_maximum;
+    aligned_int32_t   m_avail;
+    aligned_int32_t   m_waiters;
+    semaphore_t       m_sem;
+};
+
+//
+// A templatized variable signaler
+
+template<class T> class WaitVar {
+public:
+
+    void post(const T& data) {
+        {
+            ScopedLock lock(m_lock);
+            m_val = data;
+        }
+        m_sem.post();
+    };
+
+    bool wait(T& data) {
+        m_sem.wait();
+        {
+            ScopedLock lock(m_lock);
+            data = m_val;
+        }
+        return true;
+    };
+
+    bool timedWait(T& data,
+                   const double& timeout) {
+
+        if (false == m_sem.timedWait(timeout))
+            return false;
+        {
+            ScopedLock lock(m_lock);
+            data = m_val;
+        }
+        return true;
+    }
+
+    //
+    // Use a semaphore with max value of 1. The WaitVar will
+    // either be in a signaled state, or not.
+
+    WaitVar() : m_val(),
+                m_lock(),
+                m_sem(1) {};
+
+private:
+
+    T                 m_val;
+    Mutex     m_lock;
+    Semaphore m_sem;
+};
+
+//
+// A templatized wait queue
+
+template <class T> class WaitQueue {
+public:
+
+    void post(const T& data) {
+        bool postSem=true;
+        {
+            ScopedLock lock(m_lock);
+
+            //
+            // Limit deque size, if requested
+
+            if (m_maximum > 0 &&
+                m_maximum == m_queue.size()) {
+
+                //
+                // If at max entries, we will pop_front the oldest,
+                // push_back the newest, and leave the semaphore alone
+
+                m_queue.pop_front();
+                postSem = false;
+            }
+
+            m_queue.push_back(data);
+        }
+        if (postSem)
+            m_sem.post();
+    };
+
+    void kick() {
+        m_sem.post();
+    };
+
+    bool wait(T& data) {
+        m_sem.wait();
+        {
+            ScopedLock lock(m_lock);
+
+            if (0 == m_queue.size())
+                return false;
+            else {
+                data = m_queue.front();
+                m_queue.pop_front();
+                return true;
+            }
+        }
+    }
+
+    uint32_t waiters() {
+        return m_sem.waiters();
+    };
+
+    uint32_t size() {
+        ScopedLock lock(m_lock);
+        return m_queue.size();
+    }
+
+    void clear() {
+        ScopedLock lock(m_lock);
+        m_queue.clear();
+        while(false == m_sem.clear());
+    }
+
+    WaitQueue(std::size_t max=0) :
+        m_maximum(max) {};
+
+private:
+
+    const std::size_t m_maximum;
+    std::deque<T>     m_queue;
+    Mutex             m_lock;
+    Semaphore         m_sem;
+};
+
+}}}} // namespaces
+
+#endif /* #ifndef CRL_MULTISENSE_THREAD_HH */

--- a/source/LibMultiSense/details/wire/AckMessage.h
+++ b/source/LibMultiSense/details/wire/AckMessage.h
@@ -65,11 +65,12 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & command;
         message & status;
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/CamConfigMessage.h
+++ b/source/LibMultiSense/details/wire/CamConfigMessage.h
@@ -96,7 +96,35 @@ public:
     // Constructors
 
     CamConfig(utility::BufferStreamReader&r, VersionType v) {serialize(r,v);};
-    CamConfig() {};
+    CamConfig():
+        width(0),
+        height(0),
+        framesPerSecond(0.0),
+        gain(0.0),
+        exposure(0),
+        autoExposure(0),
+        autoExposureMax(0),
+        autoExposureDecay(0),
+        autoExposureThresh(0.0),
+        whiteBalanceRed(0.0),
+        whiteBalanceBlue(0.0),
+        autoWhiteBalance(0),
+        autoWhiteBalanceDecay(0),
+        autoWhiteBalanceThresh(0.0),
+        fx(0.0),
+        fy(0.0),
+        cx(0.0),
+        cy(0.0),
+        tx(0.0),
+        ty(0.0),
+        tz(0.0),
+        roll(0.0),
+        pitch(0.0),
+        yaw(0.0),
+        disparities(0),
+        stereoPostFilterStrength(0.0),
+        hdrEnabled(false)
+        {};
 
     //
     // Serialization routine
@@ -116,7 +144,7 @@ public:
         message & autoExposureMax;
         message & autoExposureDecay;
         message & autoExposureThresh;
-        
+
         message & whiteBalanceRed;
         message & whiteBalanceBlue;
         message & autoWhiteBalance;
@@ -153,6 +181,6 @@ public:
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/CamControlMessage.h
+++ b/source/LibMultiSense/details/wire/CamControlMessage.h
@@ -130,6 +130,6 @@ public:
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/CamControlMessage.h
+++ b/source/LibMultiSense/details/wire/CamControlMessage.h
@@ -50,14 +50,14 @@ namespace wire {
 class CamControl {
 public:
     static CRL_CONSTEXPR IdType      ID      = ID_CMD_CAM_CONTROL;
-    static CRL_CONSTEXPR VersionType VERSION = 3;
+    static CRL_CONSTEXPR VersionType VERSION = 4;
 
     //
     // Parameters representing the current camera configuration
 
     float    framesPerSecond;
     float    gain;
-    
+
     uint32_t exposure;
     uint8_t  autoExposure;
     uint32_t autoExposureMax;
@@ -79,6 +79,11 @@ public:
     // Additions in version 3
 
     bool     hdrEnabled;
+
+    //
+    // Additions in version 4
+
+    bool  storeSettingsInFlash;  // boolean
 
     //
     // Constructors
@@ -117,6 +122,11 @@ public:
             message & hdrEnabled;
         else
             hdrEnabled = false;
+
+        if (version >= 4)
+            message & storeSettingsInFlash;
+        else
+            storeSettingsInFlash = false;
     }
 };
 

--- a/source/LibMultiSense/details/wire/CamGetConfigMessage.h
+++ b/source/LibMultiSense/details/wire/CamGetConfigMessage.h
@@ -62,13 +62,15 @@ public:
     // Serialization routine.
 
     template<class Archive>
-        void serialize(Archive&          message, 
+        void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) message;
+        (void) version;
         // nothing yet
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/CamGetHistoryMessage.h
+++ b/source/LibMultiSense/details/wire/CamGetHistoryMessage.h
@@ -66,10 +66,12 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) message;
+        (void) version;
         // nothing yet
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/CamHistoryMessage.h
+++ b/source/LibMultiSense/details/wire/CamHistoryMessage.h
@@ -78,11 +78,12 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         for(unsigned int i = 0; i < HISTORY_LENGTH; i++)
             message & historyP[i];
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/CamSetResolutionMessage.h
+++ b/source/LibMultiSense/details/wire/CamSetResolutionMessage.h
@@ -100,6 +100,6 @@ public:
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/CamSetTriggerSourceMessage.h
+++ b/source/LibMultiSense/details/wire/CamSetTriggerSourceMessage.h
@@ -53,6 +53,7 @@ public:
 
     static CRL_CONSTEXPR uint32_t    SOURCE_INTERNAL = 0;
     static CRL_CONSTEXPR uint32_t    SOURCE_EXTERNAL = 1; // OPTO_RX
+    static CRL_CONSTEXPR uint32_t    SOURCE_EXTERNAL_INVERTED = 2; // OPTO_RX
 
     //
     // Parameters

--- a/source/LibMultiSense/details/wire/CamSetTriggerSourceMessage.h
+++ b/source/LibMultiSense/details/wire/CamSetTriggerSourceMessage.h
@@ -73,10 +73,11 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & source;
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/DisparityMessage.h
+++ b/source/LibMultiSense/details/wire/DisparityMessage.h
@@ -68,8 +68,8 @@ public:
     uint16_t width;
     uint16_t height;
 
-    DisparityHeader() 
-        : 
+    DisparityHeader()
+        :
 #ifdef SENSORPOD_FIRMWARE
         id(ID),
         version(VERSION),
@@ -91,7 +91,7 @@ public:
 
     Disparity(utility::BufferStreamReader&r, VersionType v) {serialize(r,v);};
     Disparity() : dataP(NULL) {};
-  
+
     //
     // Serialization routine
 
@@ -99,6 +99,7 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & frameId;
         message & width;
         message & height;
@@ -106,7 +107,7 @@ public:
         const uint32_t imageSize = static_cast<uint32_t> (std::ceil(((double) API_BITS_PER_PIXEL / 8.0) * width * height));
 
         if (typeid(Archive) == typeid(utility::BufferStreamWriter)) {
-          
+
             message.write(dataP, imageSize);
 
         } else {
@@ -117,13 +118,13 @@ public:
     }
 
     //
-    // UDP assembler 
+    // UDP assembler
 
     static void assembler(utility::BufferStreamWriter& stream,
                           const uint8_t               *dataP,
                           uint32_t                     offset,
                           uint32_t                     length)
-    {   
+    {
         //
         // Special case, 1st packet contains header only. Firmware
         // does not have to worry about the header length being
@@ -134,21 +135,21 @@ public:
             stream.write(dataP, META_LENGTH);
             return;
         }
-    
+
         //
-        // The data section of each incoming packet is byte-aligned 
+        // The data section of each incoming packet is byte-aligned
         // on a WIRE_BITS_PER_PIXEL boundary
 
         const uint8_t *sP           = dataP;
         const uint32_t sourceOffset = offset - META_LENGTH;
         const uint32_t count        = (8 * length) / WIRE_BITS_PER_PIXEL;
-        const uint32_t destOffset   = META_LENGTH + (((8 * sourceOffset) / WIRE_BITS_PER_PIXEL) * 
+        const uint32_t destOffset   = META_LENGTH + (((8 * sourceOffset) / WIRE_BITS_PER_PIXEL) *
                                                      (API_BITS_PER_PIXEL / 8));
         //
         // Seek to the proper location
 
         stream.seek(destOffset);
-       
+
         //
         // This conversion is for (WIRE == 12bits), (API == 16bits, 1/16th pixel, unsigned integer)
 
@@ -167,14 +168,14 @@ public:
         } else if (12 == WIRE_BITS_PER_PIXEL && 32 == API_BITS_PER_PIXEL) {
 
             float *dP = reinterpret_cast<float*>(stream.peek());
-        
+
             for(uint32_t i=0; i<count; i+=2, sP+=3) {
-                
+
                 dP[i]   = static_cast<float>((sP[0]     ) | ((sP[1] & 0x0F) << 8)) / 16.0f;
                 dP[i+1] = static_cast<float>((sP[1] >> 4) |  (sP[2] << 4)        ) / 16.0f;
             }
 
-        } else 
+        } else
             CRL_EXCEPTION("(wire==%dbits, api=%dbits) not supported",
                           WIRE_BITS_PER_PIXEL, API_BITS_PER_PIXEL);
     }
@@ -182,6 +183,6 @@ public:
 
 #endif // !SENSORPOD_FIRMWARE
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/ImageMessage.h
+++ b/source/LibMultiSense/details/wire/ImageMessage.h
@@ -64,8 +64,8 @@ static CRL_CONSTEXPR VersionType VERSION = 1;
     uint16_t width;
     uint16_t height;
 
-    ImageHeader() 
-        : 
+    ImageHeader()
+        :
 #ifdef SENSORDPOD_FIRMWARE
         id(ID),
         version(VERSION),
@@ -97,6 +97,7 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & source;
         message & bitsPerPixel;
         message & frameId;
@@ -106,7 +107,7 @@ public:
         const uint32_t imageSize = static_cast<uint32_t> (std::ceil(((double) bitsPerPixel / 8.0) * width * height));
 
         if (typeid(Archive) == typeid(utility::BufferStreamWriter)) {
-          
+
             message.write(dataP, imageSize);
 
         } else {
@@ -119,6 +120,6 @@ public:
 
 #endif // !SENSORPOD_FIRMWARE
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/ImageMetaMessage.h
+++ b/source/LibMultiSense/details/wire/ImageMetaMessage.h
@@ -70,7 +70,7 @@ public:
     uint32_t           timeMicroSeconds;
     int32_t            angle; // microradians
 
-    ImageMetaHeader() 
+    ImageMetaHeader()
         :
 #ifdef SENSORPOD_FIRMWARE
         id(ID),
@@ -81,7 +81,7 @@ public:
         gain(0.0),
         exposureTime(0),
         timeSeconds(0),
-        timeMicroSeconds(0),    
+        timeMicroSeconds(0),
         angle(0) {};
 };
 
@@ -97,7 +97,7 @@ public:
 
     ImageMeta(utility::BufferStreamReader&r, VersionType v) {serialize(r,v);};
     ImageMeta() {};
-  
+
     //
     // Serialization routine
 
@@ -105,6 +105,7 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & frameId;
         message & framesPerSecond;
         message & gain;
@@ -112,7 +113,7 @@ public:
         message & timeSeconds;
         message & timeMicroSeconds;
         message & angle;
-        
+
         if (typeid(Archive) == typeid(utility::BufferStreamWriter))
             message.write(histogramP, HISTOGRAM_LENGTH);
         else
@@ -122,6 +123,6 @@ public:
 
 #endif // !SENSORPOD_FIRMWARE
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/ImuConfigMessage.h
+++ b/source/LibMultiSense/details/wire/ImuConfigMessage.h
@@ -62,6 +62,8 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
+
         message & name;
         message & flags;
         message & rateTableIndex;
@@ -93,12 +95,13 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & storeSettingsInFlash;
         message & samplesPerMessage;
         message & configs;
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/ImuDataMessage.h
+++ b/source/LibMultiSense/details/wire/ImuDataMessage.h
@@ -62,6 +62,7 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & type;
         message & timeNanoSeconds;
         message & x;
@@ -94,6 +95,7 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & sequence;
         message & samples;
     }
@@ -101,6 +103,6 @@ public:
 
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/ImuGetConfigMessage.h
+++ b/source/LibMultiSense/details/wire/ImuGetConfigMessage.h
@@ -62,10 +62,12 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) message;
+        (void) version;
         // nothing yet
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/ImuGetInfoMessage.h
+++ b/source/LibMultiSense/details/wire/ImuGetInfoMessage.h
@@ -62,10 +62,12 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) message;
+        (void) version;
         // nothing yet
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/ImuInfoMessage.h
+++ b/source/LibMultiSense/details/wire/ImuInfoMessage.h
@@ -58,6 +58,7 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & sampleRate;
         message & bandwidthCutoff;
     }
@@ -74,6 +75,7 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & range;
         message & resolution;
     }
@@ -93,6 +95,7 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & name;
         message & device;
         message & units;
@@ -119,7 +122,7 @@ public:
 
     ImuInfo(utility::BufferStreamReader&r, VersionType v) {serialize(r,v);};
     ImuInfo() {};
-        
+
     //
     // Serialization routine
 
@@ -127,11 +130,12 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & maxSamplesPerMessage;
         message & details;
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/JpegMessage.h
+++ b/source/LibMultiSense/details/wire/JpegMessage.h
@@ -65,7 +65,7 @@ static CRL_CONSTEXPR VersionType VERSION = 1;
     uint32_t length;
     uint32_t quality;
 
-    JpegImageHeader() : 
+    JpegImageHeader() :
 #ifdef SENSORDPOD_FIRMWARE
         id(ID),
         version(VERSION),
@@ -98,6 +98,7 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & source;
         message & frameId;
         message & width;
@@ -106,7 +107,7 @@ public:
         message & quality;
 
         if (typeid(Archive) == typeid(utility::BufferStreamWriter)) {
-          
+
             message.write(dataP, length);
 
         } else {
@@ -119,6 +120,6 @@ public:
 
 #endif // !SENSORPOD_FIRMWARE
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/LedGetSensorStatusMessage.h
+++ b/source/LibMultiSense/details/wire/LedGetSensorStatusMessage.h
@@ -64,10 +64,12 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) message;
+        (void) version;
         // nothing yet
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/LedGetStatusMessage.h
+++ b/source/LibMultiSense/details/wire/LedGetStatusMessage.h
@@ -66,10 +66,12 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) message;
+        (void) version;
         // nothing yet
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/LedSensorStatusMessage.h
+++ b/source/LibMultiSense/details/wire/LedSensorStatusMessage.h
@@ -69,10 +69,11 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & ambientLightPercentage;
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/LedSetMessage.h
+++ b/source/LibMultiSense/details/wire/LedSetMessage.h
@@ -80,6 +80,7 @@ public:
         void serialize(Archiver&      archive,
                        const VersionType version)
     {
+        (void) version;
         archive & mask;
         for(uint32_t i=0; i<lighting::MAX_LIGHTS; i++)
             archive & intensity[i];
@@ -87,6 +88,6 @@ public:
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/LedStatusMessage.h
+++ b/source/LibMultiSense/details/wire/LedStatusMessage.h
@@ -75,11 +75,12 @@ public:
 
     //
     // Serialization routine
-    
+
     template<class Archive>
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & available;
         for(uint32_t i=0; i<lighting::MAX_LIGHTS; i++)
             message & intensity[i];
@@ -87,6 +88,6 @@ public:
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/LidarDataMessage.h
+++ b/source/LibMultiSense/details/wire/LidarDataMessage.h
@@ -104,6 +104,7 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & scanCount;
         message & timeStartSeconds;
         message & timeStartMicroSeconds;
@@ -134,6 +135,6 @@ public:
 
 #endif // !SENSORPOD_FIRMWARE
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/LidarPollMotorMessage.h
+++ b/source/LibMultiSense/details/wire/LidarPollMotorMessage.h
@@ -1,7 +1,9 @@
 /**
- * @file LibMultiSense/SysDirectedStreamsMessage.h
+ * @file LibMultiSense/LidarPollMotorMessage.h
  *
- * Copyright 2014
+ * This message requests the current motor encoder position of the SLB
+ *
+ * Copyright 2018
  * Carnegie Robotics, LLC
  * 4501 Hatfield Street, Pittsburgh, PA 15201
  * http://www.carnegierobotics.com
@@ -31,11 +33,11 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * Significant history (date, user, job code, action):
- *   2014-06-10, ekratzer@carnegierobotics.com, IR1069, created file.
+ *   2017-03-19, cniessl@carnegierobotics.com, PR1044, Created File
  **/
 
-#ifndef LibMultiSense_SysDirectedStreamsMessage
-#define LibMultiSense_SysDirectedStreamsMessage
+#ifndef LibMultiSense_LidarPollMotorMessage
+#define LibMultiSense_LidarPollMotorMessage
 
 #include "details/utility/Portability.hh"
 
@@ -44,58 +46,16 @@ namespace multisense {
 namespace details {
 namespace wire {
 
-class DirectedStream {
+class LidarPollMotor {
 public:
+    static CRL_CONSTEXPR IdType      ID      = ID_CMD_SYS_MOTOR_POLL;
     static CRL_CONSTEXPR VersionType VERSION = 1;
 
-    uint32_t    mask;
-    std::string address;
-    uint16_t    udpPort;
-    uint32_t    fpsDecimation;
-
-    DirectedStream() {};
-    DirectedStream(uint32_t           m,
-                   const std::string& addr,
-                   uint16_t           p,
-                   uint32_t           dec) :
-        mask(m),
-        address(addr),
-        udpPort(p),
-        fpsDecimation(dec) {};
-
-    template<class Archive>
-        void serialize(Archive&          message,
-                       const VersionType version)
-    {
-        (void) version;
-        VersionType thisVersion = VERSION;
-
-        message & thisVersion;
-        message & mask;
-        message & address;
-        message & udpPort;
-        message & fpsDecimation;
-    }
-};
-
-class SysDirectedStreams {
-public:
-    static CRL_CONSTEXPR IdType      ID        = ID_DATA_SYS_DIRECTED_STREAMS;
-    static CRL_CONSTEXPR VersionType VERSION   = 1;
-
-    static CRL_CONSTEXPR uint32_t    CMD_NONE  = 0;
-    static CRL_CONSTEXPR uint32_t    CMD_START = 1;
-    static CRL_CONSTEXPR uint32_t    CMD_STOP  = 2;
-
-    uint32_t                          command;
-    std::vector<wire::DirectedStream> streams;
-
     //
-    // Constructors
+    // Contructors
 
-    SysDirectedStreams(utility::BufferStreamReader&r, VersionType v) {serialize(r,v);};
-    SysDirectedStreams(uint32_t cmd) : command(cmd) {};
-    SysDirectedStreams() : command(CMD_NONE) {};
+    LidarPollMotor(utility::BufferStreamReader&r, VersionType v) {serialize(r,v);};
+    LidarPollMotor() {};
 
     //
     // Serialization routine
@@ -104,12 +64,9 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
-        message & command;
-        uint32_t elements = streams.size();
-        message & elements;
-        streams.resize(elements);
-        for(uint32_t i=0; i<elements; i++)
-            streams[i].serialize(message, version);
+        (void) message;
+        (void) version;
+        //Do nothing
     }
 };
 

--- a/source/LibMultiSense/details/wire/LidarSetMotorMessage.h
+++ b/source/LibMultiSense/details/wire/LidarSetMotorMessage.h
@@ -61,7 +61,8 @@ public:
     // Contructors
 
     LidarSetMotor(utility::BufferStreamReader&r, VersionType v) {serialize(r,v);};
-    LidarSetMotor(float f=0.0) : rpm(f) {};
+    LidarSetMotor() : rpm(0.0) {};
+    LidarSetMotor(float f) : rpm(f) {};
 
     //
     // Serialization routine
@@ -69,12 +70,12 @@ public:
     template<class Archive>
         void serialize(Archive&          message,
                        const VersionType version)
-                       
     {
+        (void) version;
         message & rpm;
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/PollMotorInfoMessage.h
+++ b/source/LibMultiSense/details/wire/PollMotorInfoMessage.h
@@ -1,7 +1,9 @@
 /**
- * @file LibMultiSense/SysDirectedStreamsMessage.h
+ * @file LibMultiSense/SysGetDeviceInfoMessage.h
  *
- * Copyright 2014
+ * This message contains a request for the motor encoder position
+ *
+ * Copyright 2018
  * Carnegie Robotics, LLC
  * 4501 Hatfield Street, Pittsburgh, PA 15201
  * http://www.carnegierobotics.com
@@ -31,11 +33,11 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * Significant history (date, user, job code, action):
- *   2014-06-10, ekratzer@carnegierobotics.com, IR1069, created file.
+ *   2017-03-19, cniessl@carnegierobotics.com, PR1044, Created File
  **/
 
-#ifndef LibMultiSense_SysDirectedStreamsMessage
-#define LibMultiSense_SysDirectedStreamsMessage
+#ifndef LibMultiSense_PollMotorInfoMessage
+#define LibMultiSense_PollMotorInfoMessage
 
 #include "details/utility/Portability.hh"
 
@@ -44,72 +46,29 @@ namespace multisense {
 namespace details {
 namespace wire {
 
-class DirectedStream {
+class MotorPoll {
 public:
+
+    static CRL_CONSTEXPR IdType      ID      = ID_DATA_SYS_MOTOR_POLL;
     static CRL_CONSTEXPR VersionType VERSION = 1;
 
-    uint32_t    mask;
-    std::string address;
-    uint16_t    udpPort;
-    uint32_t    fpsDecimation;
+	int32_t angleStart;
 
-    DirectedStream() {};
-    DirectedStream(uint32_t           m,
-                   const std::string& addr,
-                   uint16_t           p,
-                   uint32_t           dec) :
-        mask(m),
-        address(addr),
-        udpPort(p),
-        fpsDecimation(dec) {};
+    MotorPoll(utility::BufferStreamReader& r,
+                   VersionType v) {serialize(r,v);};
+
+	MotorPoll() :
+        angleStart(0){};
+
+	MotorPoll(int32_t a) :
+        angleStart(a){};
 
     template<class Archive>
         void serialize(Archive&          message,
                        const VersionType version)
     {
         (void) version;
-        VersionType thisVersion = VERSION;
-
-        message & thisVersion;
-        message & mask;
-        message & address;
-        message & udpPort;
-        message & fpsDecimation;
-    }
-};
-
-class SysDirectedStreams {
-public:
-    static CRL_CONSTEXPR IdType      ID        = ID_DATA_SYS_DIRECTED_STREAMS;
-    static CRL_CONSTEXPR VersionType VERSION   = 1;
-
-    static CRL_CONSTEXPR uint32_t    CMD_NONE  = 0;
-    static CRL_CONSTEXPR uint32_t    CMD_START = 1;
-    static CRL_CONSTEXPR uint32_t    CMD_STOP  = 2;
-
-    uint32_t                          command;
-    std::vector<wire::DirectedStream> streams;
-
-    //
-    // Constructors
-
-    SysDirectedStreams(utility::BufferStreamReader&r, VersionType v) {serialize(r,v);};
-    SysDirectedStreams(uint32_t cmd) : command(cmd) {};
-    SysDirectedStreams() : command(CMD_NONE) {};
-
-    //
-    // Serialization routine
-
-    template<class Archive>
-        void serialize(Archive&          message,
-                       const VersionType version)
-    {
-        message & command;
-        uint32_t elements = streams.size();
-        message & elements;
-        streams.resize(elements);
-        for(uint32_t i=0; i<elements; i++)
-            streams[i].serialize(message, version);
+    	message & angleStart;
     }
 };
 

--- a/source/LibMultiSense/details/wire/Protocol.h
+++ b/source/LibMultiSense/details/wire/Protocol.h
@@ -175,6 +175,7 @@ static CRL_CONSTEXPR IdType ID_CMD_SYS_GET_EXTERNAL_CAL     = 0x0024;
 static CRL_CONSTEXPR IdType ID_CMD_LED_GET_SENSOR_STATUS    = 0x0025;
 static CRL_CONSTEXPR IdType ID_CMD_SYS_SET_TRANSMIT_DELAY   = 0x0026;
 static CRL_CONSTEXPR IdType ID_CMD_SYS_GET_TRANSMIT_DELAY   = 0x0027;
+static CRL_CONSTEXPR IdType ID_CMD_SYS_MOTOR_POLL           = 0x0028;
 
 //
 // Data
@@ -204,6 +205,7 @@ static CRL_CONSTEXPR IdType ID_DATA_SYS_DIRECTED_STREAMS  = 0x0119;
 static CRL_CONSTEXPR IdType ID_DATA_SYS_SENSOR_CAL        = 0x011a;
 static CRL_CONSTEXPR IdType ID_DATA_SYS_EXTERNAL_CAL      = 0x011b;
 static CRL_CONSTEXPR IdType ID_DATA_LED_SENSOR_STATUS     = 0x011c;
+static CRL_CONSTEXPR IdType ID_DATA_SYS_MOTOR_POLL        = 0x011d;
 
 //
 // Data sources
@@ -225,6 +227,7 @@ static CRL_CONSTEXPR SourceType SOURCE_DISPARITY_RIGHT   = (1<<11);
 static CRL_CONSTEXPR SourceType SOURCE_DISPARITY_COST    = (1<<12);
 static CRL_CONSTEXPR SourceType SOURCE_JPEG_LEFT         = (1<<16);
 static CRL_CONSTEXPR SourceType SOURCE_RGB_LEFT          = (1<<17);
+static CRL_CONSTEXPR SourceType SOURCE_SLB_MOTOR         = (1<<23);
 static CRL_CONSTEXPR SourceType SOURCE_LIDAR_SCAN        = (1<<24);
 static CRL_CONSTEXPR SourceType SOURCE_IMU               = (1<<25);
 static CRL_CONSTEXPR SourceType SOURCE_PPS               = (1<<26);
@@ -266,6 +269,6 @@ static CRL_CONSTEXPR SourceType SOURCE_IMAGES            = (SOURCE_RAW_LEFT     
         for(uint32_t j_=0; j_<(m_); j_++)       \
             (d_)[i_][j_] = (s_)[i_][j_];        \
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/StatusRequestMessage.h
+++ b/source/LibMultiSense/details/wire/StatusRequestMessage.h
@@ -65,10 +65,12 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) message;
+        (void) version;
         // nothing yet
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/StatusResponseMessage.h
+++ b/source/LibMultiSense/details/wire/StatusResponseMessage.h
@@ -132,6 +132,6 @@ public:
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/StreamControlMessage.h
+++ b/source/LibMultiSense/details/wire/StreamControlMessage.h
@@ -80,11 +80,12 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & modifyMask;
         message & controlMask;
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysCameraCalibrationMessage.h
+++ b/source/LibMultiSense/details/wire/SysCameraCalibrationMessage.h
@@ -45,7 +45,7 @@ namespace crl {
 namespace multisense {
 namespace details {
 namespace wire {
-    
+
 class CameraCalData {
 public:
     static CRL_CONSTEXPR VersionType VERSION = 1;
@@ -59,11 +59,12 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         SER_ARRAY_2(M, 3, 3);
         SER_ARRAY_1(D, 8);
         SER_ARRAY_2(R, 3, 3);
         SER_ARRAY_2(P, 3, 4);
-    };
+    }
 };
 
 class SysCameraCalibration {
@@ -72,7 +73,7 @@ public:
     static CRL_CONSTEXPR VersionType VERSION = 1;
 
     //
-    // 2 MPix 
+    // 2 MPix
 
     CameraCalData left;
     CameraCalData right;
@@ -85,7 +86,7 @@ public:
 
     //
     // Serialization routine
-    
+
     template<class Archive>
         void serialize(Archive&          message,
                        const VersionType version)
@@ -94,6 +95,6 @@ public:
         right.serialize(message, version);
     }
 };
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysDeviceInfoMessage.h
+++ b/source/LibMultiSense/details/wire/SysDeviceInfoMessage.h
@@ -99,6 +99,7 @@ public:
     static CRL_CONSTEXPR uint32_t LIGHTING_TYPE_NONE = 0;
     static CRL_CONSTEXPR uint32_t LIGHTING_TYPE_SL_INTERNAL = 1;
     static CRL_CONSTEXPR uint32_t LIGHTING_TYPE_S21_EXTERNAL = 2;
+    static CRL_CONSTEXPR uint32_t LIGHTING_TYPE_S21_PATTERN_PROJECTOR = 3;
 
     std::string key;
     std::string name;

--- a/source/LibMultiSense/details/wire/SysDeviceInfoMessage.h
+++ b/source/LibMultiSense/details/wire/SysDeviceInfoMessage.h
@@ -60,9 +60,10 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & name;
         message & revision;
-    };
+    }
 };
 
 class SysDeviceInfo {
@@ -188,6 +189,6 @@ public:
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysDeviceModesMessage.h
+++ b/source/LibMultiSense/details/wire/SysDeviceModesMessage.h
@@ -54,7 +54,7 @@ public:
     DeviceMode(uint32_t w=0,
                uint32_t h=0,
                uint32_t s=0,
-               uint32_t d=0) : 
+               uint32_t d=0) :
         width(w),
         height(h),
         supportedDataSources(s),
@@ -74,10 +74,10 @@ public:
     //
     // Constructors
 
-    SysDeviceModes(utility::BufferStreamReader& r, 
+    SysDeviceModes(utility::BufferStreamReader& r,
                    VersionType                  v) {serialize(r,v);};
     SysDeviceModes() {};
-        
+
     //
     // Serialization routine
 
@@ -85,6 +85,7 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         uint32_t length = modes.size();
         message & length;
         modes.resize(length);
@@ -105,6 +106,6 @@ public:
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysExternalCalibrationMessage.h
+++ b/source/LibMultiSense/details/wire/SysExternalCalibrationMessage.h
@@ -69,11 +69,12 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         SER_ARRAY_1(calibration, 6);
     }
 
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysFlashOpMessage.h
+++ b/source/LibMultiSense/details/wire/SysFlashOpMessage.h
@@ -52,7 +52,7 @@ namespace wire {
 class SysFlashOp {
 public:
     static CRL_CONSTEXPR IdType      ID      = ID_CMD_SYS_FLASH_OP;
-    static CRL_CONSTEXPR VersionType VERSION = 1; 
+    static CRL_CONSTEXPR VersionType VERSION = 1;
 
     //
     // Maximum payload length per operation
@@ -89,10 +89,10 @@ public:
     // Constructors
 
     SysFlashOp(utility::BufferStreamReader&r, VersionType v) {serialize(r,v);};
-    SysFlashOp(uint32_t op=OP_STATUS, 
+    SysFlashOp(uint32_t op=OP_STATUS,
                uint32_t r=RGN_BITSTREAM,
                uint32_t s=0,
-               uint32_t l=0) : operation(op), 
+               uint32_t l=0) : operation(op),
                                region(r),
                                start_address(s),
                                length(l) {};
@@ -103,6 +103,7 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & operation;
         message & region;
 
@@ -114,7 +115,7 @@ public:
                 message & length;
 
                 if(length > MAX_LENGTH)
-                    CRL_EXCEPTION("length (%u) exceeds MAX_LENGTH (%u)", 
+                    CRL_EXCEPTION("length (%u) exceeds MAX_LENGTH (%u)",
                                   length, MAX_LENGTH);
 
                 if (typeid(Archive) == typeid(utility::BufferStreamWriter))
@@ -141,6 +142,6 @@ public:
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysFlashResponseMessage.h
+++ b/source/LibMultiSense/details/wire/SysFlashResponseMessage.h
@@ -50,7 +50,7 @@ namespace wire {
 class SysFlashResponse {
 public:
     static CRL_CONSTEXPR IdType      ID      = ID_DATA_SYS_FLASH_RESPONSE;
-    static CRL_CONSTEXPR VersionType VERSION = 1; 
+    static CRL_CONSTEXPR VersionType VERSION = 1;
 
     //
     // Parameters representing the desired flash operation
@@ -80,6 +80,7 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & status;
         message & erase_progress;
 
@@ -95,6 +96,6 @@ public:
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysGetCameraCalibrationMessage.h
+++ b/source/LibMultiSense/details/wire/SysGetCameraCalibrationMessage.h
@@ -64,10 +64,12 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) message;
+        (void) version;
         // nothing yet
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysGetDeviceInfoMessage.h
+++ b/source/LibMultiSense/details/wire/SysGetDeviceInfoMessage.h
@@ -64,10 +64,12 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) message;
+        (void) version;
         // nothing yet
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysGetDeviceModesMessage.h
+++ b/source/LibMultiSense/details/wire/SysGetDeviceModesMessage.h
@@ -62,10 +62,12 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) message;
+        (void) version;
         // nothing yet
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysGetDirectedStreamsMessage.h
+++ b/source/LibMultiSense/details/wire/SysGetDirectedStreamsMessage.h
@@ -62,11 +62,13 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) message;
+        (void) version;
         //
         // Nothing. Query only. Use a SysDirectedStreamsMessage for response
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysGetExternalCalibrationMessage.h
+++ b/source/LibMultiSense/details/wire/SysGetExternalCalibrationMessage.h
@@ -64,11 +64,13 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) message;
+        (void) version;
         // nothing yet
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif
 

--- a/source/LibMultiSense/details/wire/SysGetLidarCalibrationMessage.h
+++ b/source/LibMultiSense/details/wire/SysGetLidarCalibrationMessage.h
@@ -64,10 +64,12 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) message;
+        (void) version;
         // nothing yet
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysGetMtuMessage.h
+++ b/source/LibMultiSense/details/wire/SysGetMtuMessage.h
@@ -62,10 +62,12 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) message;
+        (void) version;
         // nothing yet
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysGetNetworkMessage.h
+++ b/source/LibMultiSense/details/wire/SysGetNetworkMessage.h
@@ -62,10 +62,12 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) message;
+        (void) version;
         // nothing yet
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysGetSensorCalibrationMessage.h
+++ b/source/LibMultiSense/details/wire/SysGetSensorCalibrationMessage.h
@@ -64,10 +64,12 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) message;
+        (void) version;
         // nothing yet
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysGetTransmitDelayMessage.h
+++ b/source/LibMultiSense/details/wire/SysGetTransmitDelayMessage.h
@@ -63,10 +63,12 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) message;
+        (void) version;
         // nothing yet
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysLidarCalibrationMessage.h
+++ b/source/LibMultiSense/details/wire/SysLidarCalibrationMessage.h
@@ -45,7 +45,7 @@ namespace crl {
 namespace multisense {
 namespace details {
 namespace wire {
-    
+
 class SysLidarCalibration {
 public:
     static CRL_CONSTEXPR IdType      ID      = ID_DATA_SYS_LIDAR_CAL;
@@ -62,16 +62,17 @@ public:
 
     //
     // Serialization routine
-    
+
     template<class Archive>
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         SER_ARRAY_2(laserToSpindle, 4, 4);
         SER_ARRAY_2(cameraToSpindleFixed, 4, 4);
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysMtuMessage.h
+++ b/source/LibMultiSense/details/wire/SysMtuMessage.h
@@ -68,10 +68,11 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & mtu;
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysNetworkMessage.h
+++ b/source/LibMultiSense/details/wire/SysNetworkMessage.h
@@ -70,7 +70,7 @@ public:
     SysNetwork(utility::BufferStreamReader&r, VersionType v) {serialize(r,v);};
     SysNetwork(const std::string& a,
                const std::string& g,
-               const std::string& n) : 
+               const std::string& n) :
         interface(Interface_Primary),
         address(a),
         gateway(g),
@@ -80,7 +80,7 @@ public:
         address(),
         gateway(),
         netmask() {};
-        
+
     //
     // Serialization routine
 
@@ -88,6 +88,7 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & interface;
         message & address;
         message & gateway;
@@ -95,6 +96,6 @@ public:
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysPpsMessage.h
+++ b/source/LibMultiSense/details/wire/SysPpsMessage.h
@@ -67,10 +67,11 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & ppsNanoSeconds;
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysSensorCalibrationMessage.h
+++ b/source/LibMultiSense/details/wire/SysSensorCalibrationMessage.h
@@ -63,11 +63,19 @@ public:
     // Constructors
 
     SysSensorCalibration(utility::BufferStreamReader&r, VersionType v) {serialize(r,v);};
-    SysSensorCalibration() {};
+    SysSensorCalibration()
+    {
+        adc_gain[0] = 0;
+        adc_gain[1] = 0;
+        bl_offset[0] = 0;
+        bl_offset[1] = 0;
+        vramp[0] = 0;
+        vramp[1] = 0;
+    };
 
     //
     // Serialization routine
-    
+
     template<class Archive>
         void serialize(Archive&          message,
                        const VersionType version)
@@ -84,6 +92,6 @@ public:
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysSensorCalibrationMessage.h
+++ b/source/LibMultiSense/details/wire/SysSensorCalibrationMessage.h
@@ -49,11 +49,15 @@ namespace wire {
 class SysSensorCalibration {
 public:
     static CRL_CONSTEXPR IdType      ID      = ID_DATA_SYS_SENSOR_CAL;
-    static CRL_CONSTEXPR VersionType VERSION = 1;
+    static CRL_CONSTEXPR VersionType VERSION = 2;
 
 
     uint8_t adc_gain[2];
     int16_t bl_offset[2];
+
+    //version 2
+
+    uint8_t vramp[2];
 
     //
     // Constructors
@@ -70,6 +74,13 @@ public:
     {
         SER_ARRAY_1(adc_gain,2);
         SER_ARRAY_1(bl_offset,2);
+
+        if(version >=2) {
+        	SER_ARRAY_1(vramp,2);
+        } else {
+            vramp[0] = 109;
+            vramp[1] = 109;
+        }
     }
 };
 

--- a/source/LibMultiSense/details/wire/SysTestMtuMessage.h
+++ b/source/LibMultiSense/details/wire/SysTestMtuMessage.h
@@ -67,10 +67,11 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & mtu;
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysTestMtuResponseMessage.h
+++ b/source/LibMultiSense/details/wire/SysTestMtuResponseMessage.h
@@ -67,6 +67,7 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & payloadSize;
         for(uint32_t i=0; i<payloadSize; ++i) {
             uint8_t dummy = 0;
@@ -75,6 +76,6 @@ public:
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/SysTransmitDelayMessage.h
+++ b/source/LibMultiSense/details/wire/SysTransmitDelayMessage.h
@@ -61,15 +61,16 @@ public:
 
     //
     // Serialization routine
-    
+
     template<class Archive>
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & delay;
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/VersionRequestMessage.h
+++ b/source/LibMultiSense/details/wire/VersionRequestMessage.h
@@ -65,10 +65,12 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) message;
+        (void) version;
         // nothing yet
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/LibMultiSense/details/wire/VersionResponseMessage.h
+++ b/source/LibMultiSense/details/wire/VersionResponseMessage.h
@@ -75,6 +75,7 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
+        (void) version;
         message & firmwareBuildDate;
         message & firmwareVersion;
         message & hardwareVersion;
@@ -83,6 +84,6 @@ public:
     }
 };
 
-}}}}; // namespaces
+}}}} // namespaces
 
 #endif

--- a/source/Utilities/CMakeLists.txt
+++ b/source/Utilities/CMakeLists.txt
@@ -21,6 +21,13 @@ set (MULTISENSE_UTILITY_LIBS
     ws2_32
 )
 
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+
+set (MULTISENSE_UTILITY_LIBS
+    MultiSense
+    pthread
+)
+
 else ()
 
 set (MULTISENSE_UTILITY_LIBS

--- a/source/Utilities/ChangeFps/CMakeLists.txt
+++ b/source/Utilities/ChangeFps/CMakeLists.txt
@@ -13,3 +13,9 @@ add_executable(ChangeFps ChangeFps.cc)
 #
 
 target_link_libraries (ChangeFps ${MULTISENSE_UTILITY_LIBS})
+
+#
+# Specify the install location
+#
+
+install(TARGETS ChangeFps RUNTIME DESTINATION "bin")

--- a/source/Utilities/ChangeFps/ChangeFps.cc
+++ b/source/Utilities/ChangeFps/ChangeFps.cc
@@ -69,22 +69,22 @@
 
 namespace {  // anonymous
 
-void usage(const char *programNameP) 
+void usage(const char *programNameP)
 {
     fprintf(stderr, "USAGE: %s [<options>]\n", programNameP);
     fprintf(stderr, "Where <options> are:\n");
     fprintf(stderr, "\t-a <current_address>    : CURRENT IPV4 address (default=10.66.171.21)\n");
     fprintf(stderr, "\t-f fps\n");
 
-    
+
     exit(-1);
 }
 
-}; // anonymous
+} // anonymous
 
 using namespace crl::multisense;
 
-int main(int    argc, 
+int main(int    argc,
          char **argvPP)
 {
     std::string currentAddress = "10.66.171.21";
@@ -145,7 +145,7 @@ int main(int    argc,
         } else {
 
             cfg.setFps(fps);
-        
+
             status = channelP->setImageConfig(cfg);
             if (Status_Ok != status) {
 				std::cerr << "Failed to configure sensor: " << Channel::statusString(status) << std::endl;

--- a/source/Utilities/ChangeIpUtility/CMakeLists.txt
+++ b/source/Utilities/ChangeIpUtility/CMakeLists.txt
@@ -13,3 +13,9 @@ add_executable(ChangeIpUtility ChangeIpUtility.cc)
 #
 
 target_link_libraries (ChangeIpUtility ${MULTISENSE_UTILITY_LIBS})
+
+#
+# Specify the install location
+#
+
+install(TARGETS ChangeIpUtility RUNTIME DESTINATION "bin")

--- a/source/Utilities/ChangeIpUtility/ChangeIpUtility.cc
+++ b/source/Utilities/ChangeIpUtility/ChangeIpUtility.cc
@@ -226,12 +226,19 @@ int main(int    argc,
             goto clean_out;
         }
 
+        #ifdef __APPLE__
+        if (setsockopt(sockfd,SOL_SOCKET,IP_RECVIF,iface.c_str(),iface.size()+1)==-1) {
+            perror("setsockopt(...SO_BINDTODEVICE) failed (are you root?)");
+            goto clean_out;
+        }
+        #else
         // bind to a specific interface so broadcast packet goes to the right place
         // note: on most systems, this will require elevated privileges
         if (setsockopt(sockfd,SOL_SOCKET,SO_BINDTODEVICE,iface.c_str(),iface.size()+1)==-1) {
             perror("setsockopt(...SO_BINDTODEVICE) failed (are you root?)");
             goto clean_out;
         }
+        #endif
 #endif
     }
 

--- a/source/Utilities/ChangeIpUtility/ChangeIpUtility.cc
+++ b/source/Utilities/ChangeIpUtility/ChangeIpUtility.cc
@@ -101,7 +101,7 @@ bool decodeIpv4(const std::string& addr,
     return true;
 }
 
-}; // anonymous
+} // anonymous
 
 using namespace crl::multisense;
 

--- a/source/Utilities/ChangeResolution/CMakeLists.txt
+++ b/source/Utilities/ChangeResolution/CMakeLists.txt
@@ -13,3 +13,9 @@ add_executable(ChangeResolution ChangeResolution.cc)
 #
 
 target_link_libraries (ChangeResolution ${MULTISENSE_UTILITY_LIBS})
+
+#
+# Specify the install location
+#
+
+install(TARGETS ChangeResolution RUNTIME DESTINATION "bin")

--- a/source/Utilities/ChangeResolution/ChangeResolution.cc
+++ b/source/Utilities/ChangeResolution/ChangeResolution.cc
@@ -89,7 +89,7 @@ void usage(const char *programNameP)
     exit(-1);
 }
 
-}; // anonymous
+} // anonymous
 
 using namespace crl::multisense;
 

--- a/source/Utilities/ChangeResolution/ChangeResolution.cc
+++ b/source/Utilities/ChangeResolution/ChangeResolution.cc
@@ -147,7 +147,7 @@ int main(int    argc,
 	std::cout << "FPGA DNA            :  0x" << std::hex << v.sensorFpgaDna << "\n";
 	std::cout << std::dec;
 
-    if (v.sensorFirmwareVersion <= 0x0305) {
+    if (v.sensorFirmwareVersion < 0x0305) {
         if (mode != 0 || offset >= 0) {
             std::cerr << "Changing crop mode of a CMV4000 imager requires v3.5 or greater, sensor is " <<
             "running v" << (v.sensorFirmwareVersion >> 8) << "." << (v.sensorFirmwareVersion & 0xff) << std::endl;

--- a/source/Utilities/ChangeTransmitDelay/CMakeLists.txt
+++ b/source/Utilities/ChangeTransmitDelay/CMakeLists.txt
@@ -13,3 +13,9 @@ add_executable(ChangeTransmitDelay ChangeTransmitDelay.cc)
 #
 
 target_link_libraries (ChangeTransmitDelay ${MULTISENSE_UTILITY_LIBS})
+
+#
+# Specify the install location
+#
+
+install(TARGETS ChangeTransmitDelay RUNTIME DESTINATION "bin")

--- a/source/Utilities/ChangeTransmitDelay/ChangeTransmitDelay.cc
+++ b/source/Utilities/ChangeTransmitDelay/ChangeTransmitDelay.cc
@@ -69,21 +69,21 @@
 
 namespace {  // anonymous
 
-void usage(const char *programNameP) 
+void usage(const char *programNameP)
 {
     fprintf(stderr, "USAGE: %s [<options>]\n", programNameP);
     fprintf(stderr, "Where <options> are:\n");
     fprintf(stderr, "\t-a <current_address>    : CURRENT IPV4 address (default=10.66.171.21)\n");
     fprintf(stderr, "\t-d transmit delay in ms\n");
-    
+
     exit(-1);
 }
 
-}; // anonymous
+} // anonymous
 
 using namespace crl::multisense;
 
-int main(int    argc, 
+int main(int    argc,
          char **argvPP)
 {
     std::string currentAddress = "10.66.171.21";
@@ -144,7 +144,7 @@ int main(int    argc,
         } else {
 
             TransmitDelay.delay = delay;
-        
+
             status = channelP->setTransmitDelay(TransmitDelay);
             if (Status_Ok != status) {
 				std::cerr << "Failed to configure transmit delay: " << Channel::statusString(status) << std::endl;

--- a/source/Utilities/DeviceInfoUtility/CMakeLists.txt
+++ b/source/Utilities/DeviceInfoUtility/CMakeLists.txt
@@ -13,3 +13,9 @@ add_executable(DeviceInfoUtility DeviceInfoUtility.cc)
 #
 
 target_link_libraries (DeviceInfoUtility ${MULTISENSE_UTILITY_LIBS})
+
+#
+# Specify the install location
+#
+
+install(TARGETS DeviceInfoUtility RUNTIME DESTINATION "bin")

--- a/source/Utilities/DeviceInfoUtility/DeviceInfoUtility.cc
+++ b/source/Utilities/DeviceInfoUtility/DeviceInfoUtility.cc
@@ -59,7 +59,7 @@ using namespace crl::multisense;
 
 namespace {  // anonymous
 
-void usage(const char *programNameP) 
+void usage(const char *programNameP)
 {
     fprintf(stderr, "USAGE: %s [<options>]\n", programNameP);
     fprintf(stderr, "Where <options> are:\n");
@@ -68,7 +68,7 @@ void usage(const char *programNameP)
     fprintf(stderr, "\t-s <file_name>     : set device info from file\n");
     fprintf(stderr, "\t-q                 : query device info (default)\n");
     fprintf(stderr, "\t-y                 : disable confirmation prompt\n");
-    
+
     exit(-1);
 }
 
@@ -94,24 +94,24 @@ void printDeviceInfo(const system::DeviceInfo& info,
      fprintf(fP, "buildDate: %s\n", info.buildDate.c_str());
      fprintf(fP, "serialNumber: %s\n", info.serialNumber.c_str());
      fprintf(fP, "hardwareRevision: %d\n\n", info.hardwareRevision);
-          
+
      fprintf(fP, "imagerName: %s\n", info.imagerName.c_str());
      fprintf(fP, "imagerType: %d\n", info.imagerType);
      fprintf(fP, "imagerWidth: %d\n", info.imagerWidth);
      fprintf(fP, "imagerHeight: %d\n\n", info.imagerHeight);
-     
+
      fprintf(fP, "lensName: %s\n", info.lensName.c_str());
      fprintf(fP, "lensType: %d\n", info.lensType);
      fprintf(fP, "nominalBaseline: %f\n", info.nominalBaseline);
      fprintf(fP, "nominalFocalLength: %f\n", info.nominalFocalLength);
      fprintf(fP, "nominalRelativeAperture: %f\n\n", info.nominalRelativeAperture);
-     
+
      fprintf(fP, "lightingType: %d\n", info.lightingType);
      fprintf(fP, "numberOfLights: %d\n\n", info.numberOfLights);
-     
+
      fprintf(fP, "laserName: %s\n", info.laserName.c_str());
      fprintf(fP, "laserType: %d\n\n", info.laserType);
-     
+
      fprintf(fP, "motorName: %s\n", info.motorName.c_str());
      fprintf(fP, "motorType: %d\n", info.motorType);
      fprintf(fP, "motorGearReduction: %f\n\n", info.motorGearReduction);
@@ -161,7 +161,7 @@ bool parseFile(const std::string& fileName,
                     x_ = std::string(tempP);                            \
                     continue;                                           \
                 }}                                                      \
-            
+
 #define CASE_INT(str_,x_)                                               \
             if (0 == strncasecmp(s, str_, strlen(str_))) {              \
                 if (1 != sscanf(s, str_"%d\n", &tempi)) {               \
@@ -171,7 +171,7 @@ bool parseFile(const std::string& fileName,
                     x_ = tempi;                                         \
                     continue;                                           \
                 }}                                                      \
-            
+
 #define CASE_FLT(str_,x_)                                               \
             if (0 == strncasecmp(s, str_, strlen(str_))) {              \
                 if (1 != sscanf(s, str_"%f\n", &tempf)) {               \
@@ -188,7 +188,7 @@ bool parseFile(const std::string& fileName,
                 fprintf(stderr, "malformed " str_ " %s\n",s);           \
                 return false;                                           \
             } else                                                      \
-                
+
 
         CASE_STR("deviceName: ",              info.name);
         CASE_STR("buildDate: ",               info.buildDate);
@@ -222,7 +222,7 @@ bool parseFile(const std::string& fileName,
             }
             continue;
         }}
-        
+
         fprintf(stderr, "malformed line: \"%s\"\n", s);
         return false;
     }
@@ -231,9 +231,9 @@ bool parseFile(const std::string& fileName,
     return true;
 }
 
-}; // anonymous
+} // anonymous
 
-int main(int    argc, 
+int main(int    argc,
          char **argvPP)
 {
     std::string ipAddress  = "10.66.171.21";
@@ -258,7 +258,7 @@ int main(int    argc,
         }
 
     if (!fileName.empty() && key.empty()) {
-        fprintf(stderr, 
+        fprintf(stderr,
                 "To program device info, please also specify the device's key with '-k'\n");
         usage(*argvPP);
     }
@@ -284,7 +284,7 @@ int main(int    argc,
 
     status = channelP->getSensorVersion(version);
     if (Status_Ok != status) {
-        fprintf(stderr, "Failed to query sensor version: %s\n", 
+        fprintf(stderr, "Failed to query sensor version: %s\n",
                 Channel::statusString(status));
         goto clean_out;
     }
@@ -293,9 +293,9 @@ int main(int    argc,
     // Parse and send device info, if requested
 
     if (!fileName.empty()) {
-        
+
         system::DeviceInfo info;
-        
+
         if (false == parseFile(fileName, info))
             goto clean_out;
         else {
@@ -305,7 +305,7 @@ int main(int    argc,
                 fprintf(stdout, "\nReally update device information? (y/n): ");
                 fflush(stdout);
                 int c = getchar();
-                
+
                 if ('Y' != c && 'y' != c) {
                     fprintf(stdout, "Aborting\n");
                     goto clean_out;
@@ -314,7 +314,7 @@ int main(int    argc,
 
             status = channelP->setDeviceInfo(key, info);
             if (Status_Ok != status) {
-                fprintf(stderr, "Failed to set the device info: %s\n", 
+                fprintf(stderr, "Failed to set the device info: %s\n",
                         Channel::statusString(status));
                 goto clean_out;
             } else
@@ -324,14 +324,14 @@ int main(int    argc,
 
     //
     // Query the current device information, if requested
-    
+
     if (query) {
 
         system::DeviceInfo info;
 
         status = channelP->getDeviceInfo(info);
         if (Status_Ok != status)
-            fprintf(stderr, "Failed to query device info: %s\n", 
+            fprintf(stderr, "Failed to query device info: %s\n",
                     Channel::statusString(status));
         else
             printDeviceInfo(info);

--- a/source/Utilities/DirectedStreamsUtility/CMakeLists.txt
+++ b/source/Utilities/DirectedStreamsUtility/CMakeLists.txt
@@ -13,3 +13,9 @@ add_executable(DirectedStreamsUtility DirectedStreamsUtility.cc)
 #
 
 target_link_libraries (DirectedStreamsUtility ${MULTISENSE_UTILITY_LIBS})
+
+#
+# Specify the install location
+#
+
+install(TARGETS DirectedStreamsUtility RUNTIME DESTINATION "bin")

--- a/source/Utilities/DirectedStreamsUtility/DirectedStreamsUtility.cc
+++ b/source/Utilities/DirectedStreamsUtility/DirectedStreamsUtility.cc
@@ -143,12 +143,14 @@ bool savePgm(const std::string& fileName,
 void ppsCallback(const pps::Header& header,
                  void              *userDataP)
 {
+    (void) userDataP;
 	std::cerr << "PPS: " << header.sensorTime << " ns" << std::endl;
 }
 
 void laserCallback(const lidar::Header& header,
                    void                *userDataP)
 {
+    (void) userDataP;
     double timeStamp = header.timeStartSeconds + 1e-6 * header.timeStartMicroSeconds;
     static double lastTimeStamp = timeStamp;
 
@@ -220,9 +222,9 @@ void disparityCallback(const image::Header& header,
 		std::cerr << "failed to get histogram for frame " << header.frameId << std::endl;
 }
 
-}; // anonymous
+} // anonymous
 
-int main(int    argc, 
+int main(int    argc,
          char **argvPP)
 {
     std::string currentAddress = "10.66.171.21";
@@ -306,7 +308,7 @@ int main(int    argc,
 
             cfg.setResolution(1024, 544);
             cfg.setFps(30.0);
-        
+
             status = channelP->setImageConfig(cfg);
             if (Status_Ok != status) {
 				std::cerr << "Failed to configure sensor: " << Channel::statusString(status) << std::endl;

--- a/source/Utilities/ExternalCalUtility/CMakeLists.txt
+++ b/source/Utilities/ExternalCalUtility/CMakeLists.txt
@@ -13,3 +13,9 @@ add_executable(ExternalCalUtility ExternalCalUtility.cc)
 #
 
 target_link_libraries (ExternalCalUtility ${MULTISENSE_UTILITY_LIBS})
+
+#
+# Specify the install location
+#
+
+install(TARGETS ExternalCalUtility RUNTIME DESTINATION "bin")

--- a/source/Utilities/ExternalCalUtility/ExternalCalUtility.cc
+++ b/source/Utilities/ExternalCalUtility/ExternalCalUtility.cc
@@ -61,16 +61,16 @@ using namespace crl::multisense;
 
 namespace {  // anonymous
 
-void usage(const char *programNameP) 
+void usage(const char *programNameP)
 {
-    fprintf(stderr, 
-            "USAGE: %s -f <calibration_file> [<options>]\n", 
+    fprintf(stderr,
+            "USAGE: %s -f <calibration_file> [<options>]\n",
             programNameP);
     fprintf(stderr, "Where <options> are:\n");
     fprintf(stderr, "\t-a <ip_address>      : ip address (default=10.66.171.21)\n");
     fprintf(stderr, "\t-s                   : set the external calibration (default is query)\n");
     fprintf(stderr, "\t-y                   : disable confirmation prompts\n");
-    
+
     exit(-1);
 }
 
@@ -100,9 +100,9 @@ std::ostream& writeCal (std::ostream& stream, system::ExternalCalibration const&
 }
 
 
-}; // anonymous
+} // anonymous
 
-int main(int    argc, 
+int main(int    argc,
          char **argvPP)
 {
     std::string        ipAddress = "10.66.171.21";
@@ -133,15 +133,15 @@ int main(int    argc,
     }
 
     if (true == setCal && false == fileExists(calFile)) {
-        
+
         fprintf(stderr, "file not found: \"%s\"\n", calFile.c_str());
         usage(*argvPP);
     }
-    
+
     if (false == setCal && true == prompt &&
         true == fileExists(calFile)) {
-        
-        fprintf(stdout, 
+
+        fprintf(stdout,
                 "\"%s\" already exists.\n\n"
                 "Really overwrite this file? (y/n): ",
                 calFile.c_str());
@@ -172,11 +172,11 @@ int main(int    argc,
 
     status = channelP->getSensorVersion(version);
     if (Status_Ok != status) {
-        fprintf(stderr, "failed to query sensor version: %s\n", 
+        fprintf(stderr, "failed to query sensor version: %s\n",
                 Channel::statusString(status));
         goto clean_out;
     }
-    
+
     //
     // Query
 
@@ -186,7 +186,7 @@ int main(int    argc,
 
         status = channelP->getExternalCalibration(c);
         if (Status_Ok != status) {
-            fprintf(stderr, "failed to query external calibration: %s\n", 
+            fprintf(stderr, "failed to query external calibration: %s\n",
                     Channel::statusString(status));
             goto clean_out;
         }
@@ -194,7 +194,7 @@ int main(int    argc,
         std::ofstream cvFile (calFile.c_str (), std::ios_base::out | std::ios_base::trunc);
 
         if (!cvFile) {
-            fprintf(stderr, "failed to open '%s' for writing\n", 
+            fprintf(stderr, "failed to open '%s' for writing\n",
                     calFile.c_str());
             goto clean_out;
         }
@@ -209,7 +209,7 @@ int main(int    argc,
         std::ifstream cvFile (calFile.c_str ());
 
         if (!cvFile) {
-            fprintf(stderr, "failed to open '%s' for reading\n", 
+            fprintf(stderr, "failed to open '%s' for reading\n",
                     calFile.c_str());
             goto clean_out;
         }
@@ -236,7 +236,7 @@ int main(int    argc,
 
         status = channelP->setExternalCalibration(c);
         if (Status_Ok != status) {
-            fprintf(stderr, "failed to set external calibration: %s\n", 
+            fprintf(stderr, "failed to set external calibration: %s\n",
                     Channel::statusString(status));
             goto clean_out;
         }

--- a/source/Utilities/FlashUtility/CMakeLists.txt
+++ b/source/Utilities/FlashUtility/CMakeLists.txt
@@ -16,9 +16,11 @@ target_link_libraries (FlashUtility ${MULTISENSE_UTILITY_LIBS})
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 else()
-    add_custom_target(MultiSenseUpdater ALL
-                      DEPENDS FlashUtility
-                      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/_MultiSenseUpdater
-                      ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MultiSenseUpdater)
-
+    install(PROGRAMS _MultiSenseUpdater DESTINATION bin RENAME MultiSenseUpdater)
 endif()
+
+#
+# Specify the install location
+#
+
+install(TARGETS FlashUtility RUNTIME DESTINATION "bin")

--- a/source/Utilities/FlashUtility/FlashUtility.cc
+++ b/source/Utilities/FlashUtility/FlashUtility.cc
@@ -56,7 +56,7 @@
 
 namespace {  // anonymous
 
-void usage(const char *programNameP) 
+void usage(const char *programNameP)
 {
     fprintf(stderr, "USAGE: %s <options>\n", programNameP);
     fprintf(stderr, "Where <options> are:\n");
@@ -99,11 +99,11 @@ bool verifyFileWithExtension(const std::string& description,
     return false;
 }
 
-}; // anonymous
+} // anonymous
 
 using namespace crl::multisense;
 
-int main(int    argc, 
+int main(int    argc,
          char **argvPP)
 {
     std::string ipAddress  = "10.66.171.21";
@@ -131,10 +131,10 @@ int main(int    argc,
     //
     // Verify that the bitstream/firmware filenames are sane, and that the files exist
 
-    if (false == bitstreamFile.empty() && 
+    if (false == bitstreamFile.empty() &&
         false == verifyFileWithExtension("Bitstream", bitstreamFile, "bin"))
         exit(-2);
-    if (false == firmwareFile.empty() && 
+    if (false == firmwareFile.empty() &&
         false == verifyFileWithExtension("Firmware", firmwareFile, "srec"))
         exit(-3);
 
@@ -147,7 +147,7 @@ int main(int    argc,
 		ipAddress.c_str());
         exit(-4);
     }
-    
+
     //
     // Perform any programming operations first
 
@@ -156,21 +156,21 @@ int main(int    argc,
     if (programOp) {
 
         if (!bitstreamFile.empty()) {
-            
+
             fprintf(stderr, "Programming bitstream: %s\n",
                     bitstreamFile.c_str());
 
-            status = channelP->flashBitstream(bitstreamFile); 
+            status = channelP->flashBitstream(bitstreamFile);
             if (Status_Ok != status) {
                 fprintf(stderr, "Programming bitstream failed: %s\n",
                         Channel::statusString(status));
-                returnCode = -6; 
+                returnCode = -6;
                 goto clean_out;
             }
         }
 
         if (!firmwareFile.empty()) {
-            
+
             fprintf(stderr, "Programming firmware: %s\n",
                     firmwareFile.c_str());
 
@@ -190,7 +190,7 @@ int main(int    argc,
     if (verifyOp) {
 
         if (!bitstreamFile.empty()) {
-            
+
             fprintf(stderr, "Verifying bitstream: %s\n",
                     bitstreamFile.c_str());
 
@@ -204,7 +204,7 @@ int main(int    argc,
         }
 
         if (!firmwareFile.empty()) {
-            
+
             fprintf(stderr, "Verifying firmware: %s\n",
                     firmwareFile.c_str());
 

--- a/source/Utilities/ImageCalUtility/CMakeLists.txt
+++ b/source/Utilities/ImageCalUtility/CMakeLists.txt
@@ -13,3 +13,9 @@ add_executable(ImageCalUtility ImageCalUtility.cc)
 #
 
 target_link_libraries (ImageCalUtility ${MULTISENSE_UTILITY_LIBS})
+
+#
+# Specify the install location
+#
+
+install(TARGETS ImageCalUtility RUNTIME DESTINATION "bin")

--- a/source/Utilities/ImageCalUtility/ImageCalUtility.cc
+++ b/source/Utilities/ImageCalUtility/ImageCalUtility.cc
@@ -61,16 +61,16 @@ using namespace crl::multisense;
 
 namespace {  // anonymous
 
-void usage(const char *programNameP) 
+void usage(const char *programNameP)
 {
-    fprintf(stderr, 
-            "USAGE: %s -e <extrinisics_file> -i <intrinsics_file> [<options>]\n", 
+    fprintf(stderr,
+            "USAGE: %s -e <extrinisics_file> -i <intrinsics_file> [<options>]\n",
             programNameP);
     fprintf(stderr, "Where <options> are:\n");
     fprintf(stderr, "\t-a <ip_address>      : ip address (default=10.66.171.21)\n");
     fprintf(stderr, "\t-s                   : set the calibration (default is query)\n");
     fprintf(stderr, "\t-y                   : disable confirmation prompts\n");
-    
+
     exit(-1);
 }
 
@@ -100,9 +100,9 @@ std::ostream& writeImageExtrinics (std::ostream& stream, image::Calibration cons
     return stream;
 }
 
-}; // anonymous
+} // anonymous
 
-int main(int    argc, 
+int main(int    argc,
          char **argvPP)
 {
     std::string ipAddress = "10.66.171.21";
@@ -137,7 +137,7 @@ int main(int    argc,
     if (true == setCal &&
         (false == fileExists(intrinsicsFile) ||
          false == fileExists(extrinsicsFile))) {
-        
+
         fprintf(stderr, "intrinsics or extrinsics file not found\n");
         usage(*argvPP);
     }
@@ -145,8 +145,8 @@ int main(int    argc,
     if (false == setCal && true == prompt &&
         (true == fileExists(intrinsicsFile) ||
          true == fileExists(extrinsicsFile))) {
-        
-        fprintf(stdout, 
+
+        fprintf(stdout,
                 "One or both of \"%s\" and \"%s\" already exists.\n\n"
                 "Really overwrite these files? (y/n): ",
                 intrinsicsFile.c_str(),
@@ -158,7 +158,7 @@ int main(int    argc,
             fprintf(stdout, "Aborting\n");
             return 0;
         }
-    }       
+    }
 
     //
     // Initialize communications.
@@ -178,11 +178,11 @@ int main(int    argc,
 
     status = channelP->getSensorVersion(version);
     if (Status_Ok != status) {
-        fprintf(stderr, "failed to query sensor version: %s\n", 
+        fprintf(stderr, "failed to query sensor version: %s\n",
                 Channel::statusString(status));
         goto clean_out;
     }
-    
+
     //
     // Query
 
@@ -192,7 +192,7 @@ int main(int    argc,
 
         status = channelP->getImageCalibration(c);
         if (Status_Ok != status) {
-            fprintf(stderr, "failed to query image calibration: %s\n", 
+            fprintf(stderr, "failed to query image calibration: %s\n",
                     Channel::statusString(status));
             goto clean_out;
         }
@@ -202,7 +202,7 @@ int main(int    argc,
         inFile.open (intrinsicsFile.c_str (), std::ios_base::out | std::ios_base::trunc);
 
         if (!inFile) {
-            fprintf(stderr, "failed to open '%s' for writing\n", 
+            fprintf(stderr, "failed to open '%s' for writing\n",
                     intrinsicsFile.c_str());
             goto clean_out;
         }
@@ -210,7 +210,7 @@ int main(int    argc,
         exFile.open (extrinsicsFile.c_str (), std::ios_base::out | std::ios_base::trunc);
 
         if (!exFile) {
-            fprintf(stderr, "failed to open '%s' for writing\n", 
+            fprintf(stderr, "failed to open '%s' for writing\n",
                     extrinsicsFile.c_str());
             goto clean_out;
         }
@@ -227,9 +227,9 @@ int main(int    argc,
         std::map<std::string, std::vector<float> > data;
 
         inFile.open (intrinsicsFile.c_str ());
-        
+
         if (!inFile) {
-            fprintf(stderr, "failed to open '%s' for reading\n", 
+            fprintf(stderr, "failed to open '%s' for reading\n",
                     intrinsicsFile.c_str());
             goto clean_out;
         }
@@ -250,7 +250,7 @@ int main(int    argc,
         exFile.open (extrinsicsFile.c_str ());
 
         if (!exFile) {
-            fprintf(stderr, "failed to open '%s' for reading\n", 
+            fprintf(stderr, "failed to open '%s' for reading\n",
                     extrinsicsFile.c_str());
             goto clean_out;
         }
@@ -284,7 +284,7 @@ int main(int    argc,
 
         status = channelP->setImageCalibration(c);
         if (Status_Ok != status) {
-            fprintf(stderr, "failed to set image calibration: %s\n", 
+            fprintf(stderr, "failed to set image calibration: %s\n",
                     Channel::statusString(status));
             goto clean_out;
         }

--- a/source/Utilities/ImuConfigUtility/CMakeLists.txt
+++ b/source/Utilities/ImuConfigUtility/CMakeLists.txt
@@ -13,3 +13,9 @@ add_executable(ImuConfigUtility ImuConfigUtility.cc)
 #
 
 target_link_libraries (ImuConfigUtility ${MULTISENSE_UTILITY_LIBS})
+
+#
+# Specify the install location
+#
+
+install(TARGETS ImuConfigUtility RUNTIME DESTINATION "bin")

--- a/source/Utilities/ImuConfigUtility/ImuConfigUtility.cc
+++ b/source/Utilities/ImuConfigUtility/ImuConfigUtility.cc
@@ -69,7 +69,7 @@ std::vector<imu::Config> sensor_configs;
 uint32_t                 sensor_samplesPerMessage    = 0;
 uint32_t                 sensor_maxSamplesPerMessage = 0;
 
-void usage(const char *programNameP) 
+void usage(const char *programNameP)
 {
 	std::cerr << "USAGE: " << programNameP << " [<options>]" << std::endl;
 	std::cerr << "Where <options> are:" << std::endl;
@@ -93,7 +93,7 @@ bool imuInfoByName(const std::string& name, imu::Info& info)
 {
     std::vector<imu::Info>::const_iterator it = sensor_infos.begin();
 
-    for(; it != sensor_infos.end(); ++it) 
+    for(; it != sensor_infos.end(); ++it)
         if (name == (*it).name) {
             info = (*it);
             return true;
@@ -102,9 +102,9 @@ bool imuInfoByName(const std::string& name, imu::Info& info)
     return false;
 }
 
-}; // anonymous
+} // anonymous
 
-int main(int    argc, 
+int main(int    argc,
          char **argvPP)
 {
     std::string              currentAddress         = "10.66.171.21";
@@ -223,9 +223,9 @@ int main(int    argc,
         std::cout << "\nCurrent IMU configuration:\n";
 		std::cout << "\t-s " << sensor_samplesPerMessage << " ";
         for(uint32_t i=0; i<sensor_configs.size(); i++) {
-            
+
             const imu::Config& c = sensor_configs[i];
-            
+
 			std::cout << "-c \"" << c.name << " " << (c.enabled ? "true" : "false") << " " <<
 				c.rateTableIndex << " " << c.rangeTableIndex << "\" ";
         }
@@ -249,7 +249,7 @@ int main(int    argc,
         // Validate each command line config option against IMU information from the head
 
         for(uint32_t i=0; i<cli_configs.size(); i++) {
-        
+
             char nameP[32]    = {0};
             char enabledP[32] = {0};
             int  rate         = -1;
@@ -321,7 +321,7 @@ int main(int    argc,
     }
 
 clean_out:
-        
+
     Channel::Destroy(channelP);
     return 0;
 }

--- a/source/Utilities/ImuTestUtility/CMakeLists.txt
+++ b/source/Utilities/ImuTestUtility/CMakeLists.txt
@@ -13,3 +13,9 @@ add_executable(ImuTestUtility ImuTestUtility.cc)
 #
 
 target_link_libraries (ImuTestUtility ${MULTISENSE_UTILITY_LIBS})
+
+#
+# Specify the install location
+#
+
+install(TARGETS ImuTestUtility RUNTIME DESTINATION "bin")

--- a/source/Utilities/ImuTestUtility/ImuTestUtility.cc
+++ b/source/Utilities/ImuTestUtility/ImuTestUtility.cc
@@ -71,14 +71,14 @@ int64_t       sequence      = -1;
 uint32_t      messages      = 0;
 uint32_t      dropped       = 0;
 
-void usage(const char *programNameP) 
+void usage(const char *programNameP)
 {
     std::cerr << "USAGE: " << programNameP << " [<options>]" << std::endl;
     std::cerr << "Where <options> are:" << std::endl;
     std::cerr << "\t-a <ip_address>    : IPV4 address (default=10.66.171.21)" << std::endl;
     std::cerr << "\t-m <mtu>           : default=7200" << std::endl;
     std::cerr << "\t-f <log_file>      : FILE to log IMU data (stdout by default)" << std::endl;
-    
+
     exit(-1);
 }
 
@@ -100,6 +100,7 @@ void signalHandler(int sig)
 void imuCallback(const imu::Header& header,
                  void              *userDataP)
 {
+    (void) userDataP;
     std::vector<imu::Sample>::const_iterator it = header.samples.begin();
 
     for(; it!=header.samples.end(); ++it) {
@@ -114,7 +115,7 @@ void imuCallback(const imu::Header& header,
 
         if (logFileP)
             fprintf(logFileP, "%d %.6f %.6f %.6f %.6f\n",
-                    s.type, 
+                    s.type,
                     s.timeSeconds + 1e-6 * s.timeMicroSeconds,
                     s.x, s.y, s.z);
     }
@@ -130,9 +131,9 @@ void imuCallback(const imu::Header& header,
     messages ++;
 }
 
-}; // anonymous
+} // anonymous
 
-int main(int    argc, 
+int main(int    argc,
          char **argvPP)
 {
     std::string currentAddress = "10.66.171.21";
@@ -174,7 +175,7 @@ int main(int    argc,
 
     Status status = channelP->getVersionInfo(v);
     if (Status_Ok != status) {
-        std::cerr << "Failed to query sensor version: " << Channel::statusString(status) << std::endl; 
+        std::cerr << "Failed to query sensor version: " << Channel::statusString(status) << std::endl;
         goto clean_out;
     }
 
@@ -192,7 +193,7 @@ int main(int    argc,
 
     status = channelP->stopStreams(Source_All);
     if (Status_Ok != status) {
-        std::cerr << "Failed to stop streams: " << Channel::statusString(status) << std::endl; 
+        std::cerr << "Failed to stop streams: " << Channel::statusString(status) << std::endl;
         goto clean_out;
     }
 
@@ -200,7 +201,7 @@ int main(int    argc,
     // Was logging requested ?
 
     if (NULL != logFileNameP) {
-        
+
         //
         // Open the log file
 
@@ -231,13 +232,13 @@ int main(int    argc,
 
     status = channelP->startStreams(Source_Imu);
     if (Status_Ok != status) {
-        std::cerr << "Failed to start streams: " << Channel::statusString(status) << std::endl; 
+        std::cerr << "Failed to start streams: " << Channel::statusString(status) << std::endl;
         goto clean_out;
     }
 
     while(!doneG)
         usleep(100000);
-        
+
     //
     // Stop streaming
 
@@ -258,14 +259,14 @@ int main(int    argc,
                          "gyro: " << std::fixed << std::setprecision(1) << (100.0 * static_cast<double>(gyro_samples) / static_cast<double>(imu_total)) << "%, " <<
                          "mag: " << std::fixed << std::setprecision(1) << (100.0 * static_cast<double>(mag_samples) / static_cast<double>(imu_total)) << "%" << std::endl;
         }
-        
-        if (messages > 0) 
+
+        if (messages > 0)
             std::cerr << "IMU messages: total: " << messages << ", " <<
                          "dropped: " << dropped << "(" << std::fixed << std::setprecision(6) << (100* static_cast<double>(dropped) / static_cast<double>(messages+dropped)) << "%)" << std::endl;
     }
 
 clean_out:
-        
+
     if (logFileNameP)
         fclose(logFileP);
 

--- a/source/Utilities/LidarCalUtility/CMakeLists.txt
+++ b/source/Utilities/LidarCalUtility/CMakeLists.txt
@@ -13,3 +13,9 @@ add_executable(LidarCalUtility LidarCalUtility.cc)
 #
 
 target_link_libraries (LidarCalUtility ${MULTISENSE_UTILITY_LIBS})
+
+#
+# Specify the install location
+#
+
+install(TARGETS LidarCalUtility RUNTIME DESTINATION "bin")

--- a/source/Utilities/LidarCalUtility/LidarCalUtility.cc
+++ b/source/Utilities/LidarCalUtility/LidarCalUtility.cc
@@ -61,16 +61,16 @@ using namespace crl::multisense;
 
 namespace {  // anonymous
 
-void usage(const char *programNameP) 
+void usage(const char *programNameP)
 {
-    fprintf(stderr, 
-            "USAGE: %s -f <calibration_file> [<options>]\n", 
+    fprintf(stderr,
+            "USAGE: %s -f <calibration_file> [<options>]\n",
             programNameP);
     fprintf(stderr, "Where <options> are:\n");
     fprintf(stderr, "\t-a <ip_address>      : ip address (default=10.66.171.21)\n");
     fprintf(stderr, "\t-s                   : set the calibration (default is query)\n");
     fprintf(stderr, "\t-y                   : disable confirmation prompts\n");
-    
+
     exit(-1);
 }
 
@@ -93,9 +93,9 @@ std::ostream& writeLaserCal (std::ostream& stream, lidar::Calibration const& cal
 }
 
 
-}; // anonymous
+} // anonymous
 
-int main(int    argc, 
+int main(int    argc,
          char **argvPP)
 {
     std::string        ipAddress = "10.66.171.21";
@@ -126,15 +126,15 @@ int main(int    argc,
     }
 
     if (true == setCal && false == fileExists(calFile)) {
-        
+
         fprintf(stderr, "file not found: \"%s\"\n", calFile.c_str());
         usage(*argvPP);
     }
-    
+
     if (false == setCal && true == prompt &&
         true == fileExists(calFile)) {
-        
-        fprintf(stdout, 
+
+        fprintf(stdout,
                 "\"%s\" already exists.\n\n"
                 "Really overwrite this file? (y/n): ",
                 calFile.c_str());
@@ -165,11 +165,11 @@ int main(int    argc,
 
     status = channelP->getSensorVersion(version);
     if (Status_Ok != status) {
-        fprintf(stderr, "failed to query sensor version: %s\n", 
+        fprintf(stderr, "failed to query sensor version: %s\n",
                 Channel::statusString(status));
         goto clean_out;
     }
-    
+
     //
     // Query
 
@@ -179,7 +179,7 @@ int main(int    argc,
 
         status = channelP->getLidarCalibration(c);
         if (Status_Ok != status) {
-            fprintf(stderr, "failed to query lidar calibration: %s\n", 
+            fprintf(stderr, "failed to query lidar calibration: %s\n",
                     Channel::statusString(status));
             goto clean_out;
         }
@@ -187,7 +187,7 @@ int main(int    argc,
         std::ofstream cvFile (calFile.c_str (), std::ios_base::out | std::ios_base::trunc);
 
         if (!cvFile) {
-            fprintf(stderr, "failed to open '%s' for writing\n", 
+            fprintf(stderr, "failed to open '%s' for writing\n",
                     calFile.c_str());
             goto clean_out;
         }
@@ -202,7 +202,7 @@ int main(int    argc,
         std::ifstream cvFile (calFile.c_str ());
 
         if (!cvFile) {
-            fprintf(stderr, "failed to open '%s' for reading\n", 
+            fprintf(stderr, "failed to open '%s' for reading\n",
                     calFile.c_str());
             goto clean_out;
         }
@@ -223,10 +223,10 @@ int main(int    argc,
 
         memcpy (&c.laserToSpindle[0][0], &data[laserToSpindleNameP].front (), data[laserToSpindleNameP].size () * sizeof (float));
         memcpy (&c.cameraToSpindleFixed[0][0], &data[cameraToSpindleFixedNameP].front (), data[cameraToSpindleFixedNameP].size () * sizeof (float));
-        
+
         status = channelP->setLidarCalibration(c);
         if (Status_Ok != status) {
-            fprintf(stderr, "failed to set lidar calibration: %s\n", 
+            fprintf(stderr, "failed to set lidar calibration: %s\n",
                     Channel::statusString(status));
             goto clean_out;
         }

--- a/source/Utilities/SaveImageUtility/CMakeLists.txt
+++ b/source/Utilities/SaveImageUtility/CMakeLists.txt
@@ -13,3 +13,9 @@ add_executable(SaveImageUtility SaveImageUtility.cc)
 #
 
 target_link_libraries (SaveImageUtility ${MULTISENSE_UTILITY_LIBS})
+
+#
+# Specify the install location
+#
+
+install(TARGETS SaveImageUtility RUNTIME DESTINATION "bin")

--- a/source/Utilities/SaveImageUtility/SaveImageUtility.cc
+++ b/source/Utilities/SaveImageUtility/SaveImageUtility.cc
@@ -66,12 +66,12 @@ namespace {  // anonymous
 
 volatile bool doneG = false;
 
-void usage(const char *programNameP) 
+void usage(const char *programNameP)
 {
 	std::cerr << "USAGE: " << programNameP << " [<options>]" << std::endl;
     std::cerr << "Where <options> are:" << std::endl;
 	std::cerr << "\t-a <current_address>    : CURRENT IPV4 address (default=10.66.171.21)" << std::endl;
-    
+
     exit(-1);
 }
 
@@ -97,7 +97,7 @@ bool savePgm(const std::string& fileName,
              const void        *dataP)
 {
     std::ofstream outputStream(fileName.c_str(), std::ios::binary | std::ios::out);
-    
+
     if (false == outputStream.good()) {
 		std::cerr << "Failed to open \"" << fileName << "\"" << std::endl;
         return false;
@@ -106,13 +106,13 @@ bool savePgm(const std::string& fileName,
     const uint32_t imageSize = height * width;
 
     switch(bitsPerPixel) {
-    case 8: 
+    case 8:
     {
 
         outputStream << "P5\n"
                      << width << " " << height << "\n"
                      << 0xFF << "\n";
-        
+
         outputStream.write(reinterpret_cast<const char*>(dataP), imageSize);
 
         break;
@@ -124,7 +124,7 @@ bool savePgm(const std::string& fileName,
                      << 0xFFFF << "\n";
 
         const uint16_t *imageP = reinterpret_cast<const uint16_t*>(dataP);
-        
+
         for (uint32_t i=0; i<imageSize; ++i) {
             uint16_t o = htons(imageP[i]);
             outputStream.write(reinterpret_cast<const char*>(&o), sizeof(uint16_t));
@@ -133,7 +133,7 @@ bool savePgm(const std::string& fileName,
         break;
     }
     }
-        
+
     outputStream.close();
     return true;
 }
@@ -142,7 +142,7 @@ void ppsCallback(const pps::Header& header,
                  void              *userDataP)
 {
 	std::cerr << "PPS: " << header.sensorTime << " ns" << std::endl;
-}                
+}
 
 void laserCallback(const lidar::Header& header,
                    void                *userDataP)
@@ -154,9 +154,9 @@ void imageCallback(const image::Header& header,
                    void                *userDataP)
 {
     Channel *channelP = reinterpret_cast<Channel*>(userDataP);
-    
+
 //    double timeStamp = header.timeSeconds + 1e-6 * header.timeMicroSeconds;
-    
+
     static int64_t lastFrameId = -1;
 
     if (-1 == lastFrameId)
@@ -178,7 +178,7 @@ void imageCallback(const image::Header& header,
 
 }; // anonymous
 
-int main(int    argc, 
+int main(int    argc,
          char **argvPP)
 {
     std::string currentAddress = "10.66.171.21";
@@ -247,7 +247,7 @@ int main(int    argc,
 
             cfg.setResolution(1024, 544);
             cfg.setFps(30.0);
-        
+
             status = channelP->setImageConfig(cfg);
             if (Status_Ok != status) {
 				std::cerr << "Failed to configure sensor: " << Channel::statusString(status) << std::endl;

--- a/source/Utilities/SaveImageUtility/SaveImageUtility.cc
+++ b/source/Utilities/SaveImageUtility/SaveImageUtility.cc
@@ -141,21 +141,21 @@ bool savePgm(const std::string& fileName,
 void ppsCallback(const pps::Header& header,
                  void              *userDataP)
 {
+    (void) userDataP;
 	std::cerr << "PPS: " << header.sensorTime << " ns" << std::endl;
 }
 
 void laserCallback(const lidar::Header& header,
                    void                *userDataP)
 {
-// 	std::cerr << "lidar: " << header.pointCount << std::endl;
+    (void) userDataP;
+    std::cerr << "lidar: " << header.pointCount << std::endl;
 }
 
 void imageCallback(const image::Header& header,
                    void                *userDataP)
 {
     Channel *channelP = reinterpret_cast<Channel*>(userDataP);
-
-//    double timeStamp = header.timeSeconds + 1e-6 * header.timeMicroSeconds;
 
     static int64_t lastFrameId = -1;
 
@@ -176,7 +176,7 @@ void imageCallback(const image::Header& header,
 		std::cerr << "failed to get histogram for frame " << header.frameId << std::endl;
 }
 
-}; // anonymous
+} // anonymous
 
 int main(int    argc,
          char **argvPP)

--- a/source/Utilities/SensorCalUtility/CMakeLists.txt
+++ b/source/Utilities/SensorCalUtility/CMakeLists.txt
@@ -13,3 +13,9 @@ add_executable(SensorCalUtility SensorCalUtility.cc)
 #
 
 target_link_libraries (SensorCalUtility ${MULTISENSE_UTILITY_LIBS})
+
+#
+# Specify the install location
+#
+
+install(TARGETS SensorCalUtility RUNTIME DESTINATION "bin")

--- a/source/Utilities/SensorCalUtility/SensorCalUtility.cc
+++ b/source/Utilities/SensorCalUtility/SensorCalUtility.cc
@@ -86,10 +86,10 @@ std::string bytes_to_binary(uint64_t x, int bits)
     return b.erase(0,(currentByte*8 - bits));
 }
 
-void usage(const char *programNameP) 
+void usage(const char *programNameP)
 {
-    fprintf(stderr, 
-            "USAGE: %s [<options>]\n", 
+    fprintf(stderr,
+            "USAGE: %s [<options>]\n",
             programNameP);
     fprintf(stderr, "Where <options> are:\n");
     fprintf(stderr, "\t-a <ip_address>      : ip address (default=10.66.171.21)\n");
@@ -98,19 +98,13 @@ void usage(const char *programNameP)
     fprintf(stderr, "\t-r                   : set the right calibration \n");
     fprintf(stderr, "\t-e                   : set the right black level \n");
     fprintf(stderr, "\t-k                   : set the left black level \n");
-    
+
     exit(-1);
 }
 
-bool fileExists(const std::string& name)
-{
-    struct stat sbuf;
-    return (0 == stat(name.c_str(), &sbuf));
-}
+} // anonymous
 
-}; // anonymous
-
-int main(int    argc, 
+int main(int    argc,
          char **argvPP)
 {
     Status status = Status_Ok;
@@ -119,8 +113,8 @@ int main(int    argc,
     std::string rightIn = "50";
     std::string leftBlackIn = "-61";
     std::string rightBlackIn = "-61";
-	uint8_t left;
-	uint8_t right;
+	int left;
+	int right;
     int16_t leftBlack;
     int16_t rightBlack;
     bool        setCal=false;
@@ -171,7 +165,7 @@ int main(int    argc,
 
     status = channelP->getSensorCalibration(sensorCalibration);
     if (Status_Ok != status) {
-        fprintf(stderr, "failed to query sensor calibration: %s\n", 
+        fprintf(stderr, "failed to query sensor calibration: %s\n",
                 Channel::statusString(status));
         goto clean_out;
     }
@@ -220,7 +214,7 @@ int main(int    argc,
 
     if (false == setCal) {
 
-        fprintf(stdout,"left sensor gain: %hu\nright sensor gain %hu\nleft sensor black level: %d\nright sensor black level %d\nleft sensor vramp: %d\nright sensor vramp %d\n", 
+        fprintf(stdout,"left sensor gain: %hu\nright sensor gain %hu\nleft sensor black level: %d\nright sensor black level %d\nleft sensor vramp: %d\nright sensor vramp %d\n",
                     sensorCalibration.adc_gain[0], sensorCalibration.adc_gain[1],
                     sensorCalibration.bl_offset[0], sensorCalibration.bl_offset[1],
                     sensorCalibration.vramp[0], sensorCalibration.vramp[1]);
@@ -230,7 +224,7 @@ int main(int    argc,
         fprintf(stdout,"Setting :\nleft sensor gain: %5hu binary: %s\n"
                                    "right sensor gain %5hu binary: %s\n"
                                    "left sensor black level: %d binary: %s\n"
-                                   "right sensor black level %d binary: %s\n", 
+                                   "right sensor black level %d binary: %s\n",
                     sensorCalibration.adc_gain[0],byte_to_binary(sensorCalibration.adc_gain[0]).c_str(),
                     sensorCalibration.adc_gain[1],byte_to_binary(sensorCalibration.adc_gain[1]).c_str(),
                     sensorCalibration.bl_offset[0],bytes_to_binary(sensorCalibration.bl_offset[0], 14).c_str(),
@@ -238,7 +232,7 @@ int main(int    argc,
 
         status = channelP->setSensorCalibration(sensorCalibration);
         if (Status_Ok != status) {
-            fprintf(stderr, "failed to set sensor calibration: %s\n", 
+            fprintf(stderr, "failed to set sensor calibration: %s\n",
                     Channel::statusString(status));
             goto clean_out;
         }

--- a/source/Utilities/SensorCalUtility/SensorCalUtility.cc
+++ b/source/Utilities/SensorCalUtility/SensorCalUtility.cc
@@ -220,9 +220,10 @@ int main(int    argc,
 
     if (false == setCal) {
 
-        fprintf(stdout,"left sensor gain: %hu\nright sensor gain %hu\nleft sensor black level: %d\nright sensor black level %d\n", 
+        fprintf(stdout,"left sensor gain: %hu\nright sensor gain %hu\nleft sensor black level: %d\nright sensor black level %d\nleft sensor vramp: %d\nright sensor vramp %d\n", 
                     sensorCalibration.adc_gain[0], sensorCalibration.adc_gain[1],
-                    sensorCalibration.bl_offset[0], sensorCalibration.bl_offset[1]);
+                    sensorCalibration.bl_offset[0], sensorCalibration.bl_offset[1],
+                    sensorCalibration.vramp[0], sensorCalibration.vramp[1]);
 
     } else {
 

--- a/source/Utilities/portability/getopt/CMakeLists.txt
+++ b/source/Utilities/portability/getopt/CMakeLists.txt
@@ -5,3 +5,10 @@
 add_library (getopt STATIC
     getopt.c
 )
+
+#
+# Specify the install location
+#
+install(TARGETS getopt
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib)


### PR DESCRIPTION
The CMake has been updated to use the standard install procedure. Instead of making a `bin` directory next to the `build` directory, CMake now installs files in the `CMAKE_INSTALL_PREFIX` location when the user runs `make install`

The CMake option `MULTISENSE_BUILD_UTILITIES` has been added for users that do not want to build the utilities with the API

Trailing whitespace and unnecessary semicolons have been removed from most files