### PR TITLE
Install header files to prefix using target properties

### DIFF
--- a/source/LibMultiSense/CMakeLists.txt
+++ b/source/LibMultiSense/CMakeLists.txt
@@ -79,5 +79,3 @@ install(TARGETS MultiSense
 
 install(EXPORT MultiSenseConfig
     DESTINATION lib/cmake/MultiSense)
-
-#install(FILES ${MULTISENSE_HEADERS} DESTINATION include/MultiSense)

--- a/source/LibMultiSense/CMakeLists.txt
+++ b/source/LibMultiSense/CMakeLists.txt
@@ -52,6 +52,10 @@ add_library(MultiSense SHARED ${MULTISENSE_HEADERS}
 
 set_target_properties(MultiSense PROPERTIES VERSION "3.8")
 
+target_include_directories(MultiSense INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
+
+set_target_properties(MultiSense PROPERTIES PUBLIC_HEADER "${MULTISENSE_HEADERS}")
+
 #
 # We want to link against our child libraries.
 #
@@ -68,6 +72,7 @@ endif()
 install(TARGETS MultiSense
   EXPORT MultiSenseConfig
   LIBRARY DESTINATION lib
+  PUBLIC_HEADER DESTINATION include/MultiSense
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin
 )
@@ -75,4 +80,4 @@ install(TARGETS MultiSense
 install(EXPORT MultiSenseConfig
     DESTINATION lib/cmake/MultiSense)
 
-install(FILES ${MULTISENSE_HEADERS} DESTINATION include/MultiSense)
+#install(FILES ${MULTISENSE_HEADERS} DESTINATION include/MultiSense)


### PR DESCRIPTION
Using pre-3 features, we want to install headers to a prefix as a part of the target, so that when you link against MultiSense in cmake, you find the headers automatically.