### PR TITLE
Update yaml parsing to handle dashes from OpenCV

### DIFF
--- a/source/Utilities/shared/CalibrationYaml.hh
+++ b/source/Utilities/shared/CalibrationYaml.hh
@@ -153,7 +153,7 @@ std::istream& parseYaml (std::istream& stream, std::map<std::string, std::vector
     {
         input = 0;
         stream >> input;
-        if (input == '%')
+        if (input == '%' || input == '-')
         {
             std::string comment;
             std::getline (stream, comment);


### PR DESCRIPTION
This will handle the `---` lines which OpenCV tends to put in ouput yaml files. 