### PR TITLE
Add support for custom camera profiles

### DIFF
--- a/source/LibMultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/MultiSenseTypes.hh
@@ -145,6 +145,16 @@ static CRL_CONSTEXPR DataSource Source_Disparity_Aux          = (1U<<31);
  */
 static CRL_CONSTEXPR int Roi_Full_Image = 0;
 
+#if __cplusplus > 199711L
+enum class CameraProfile
+#else
+enum CameraProfile
+#endif
+{
+    /** User has direct control over all settings in the image configuration*/
+    USER_CONTROL = 0
+};
+
 /**
  * Class used to request that MultiSense data be sent to a 3rd-party
  * stream destination (UDP port), currently supported only by CRL's
@@ -747,6 +757,16 @@ public:
         m_autoExposureRoiHeight = height;
     }
 
+    /**
+     * Set the operation profile for the camera to use. Profile settings subsume other user settings.
+     *
+     * @param profile The operation profile to use on the camera
+     */
+    void setCameraProfile(const CameraProfile &profile)
+    {
+        m_profile = profile;
+    }
+
     //
     // Query
 
@@ -775,7 +795,7 @@ public:
     uint32_t disparities () const { return m_disparities; };
 
     /**
-     * Query the current image configuration's mode
+     * Query the current image configuration's mode.
      *
      * @return The current camera mode
      */
@@ -941,6 +961,13 @@ public:
      */
     uint16_t autoExposureRoiHeight   () const { return m_autoExposureRoiHeight; };
 
+    /**
+     * Query the current image configurations camera profile
+     *
+     * @return The current image configurations camera profile
+     */
+    CameraProfile cameraProfile () const { return m_profile; };
+
     //
     // Query camera calibration (read-only)
     //
@@ -1065,6 +1092,7 @@ public:
                m_hdrEnabled(false), m_storeSettingsInFlash(false),
                m_autoExposureRoiX(0), m_autoExposureRoiY(0),
                m_autoExposureRoiWidth(Roi_Full_Image), m_autoExposureRoiHeight(Roi_Full_Image),
+               m_profile(CameraProfile::USER_CONTROL),
                m_fx(0), m_fy(0), m_cx(0), m_cy(0),
                m_tx(0), m_ty(0), m_tz(0), m_roll(0), m_pitch(0), m_yaw(0) {};
 private:
@@ -1091,6 +1119,7 @@ private:
     uint16_t m_autoExposureRoiY;
     uint16_t m_autoExposureRoiWidth;
     uint16_t m_autoExposureRoiHeight;
+    CameraProfile m_profile;
 
 protected:
 

--- a/source/LibMultiSense/details/public.cc
+++ b/source/LibMultiSense/details/public.cc
@@ -701,6 +701,8 @@ Status impl::getImageConfig(image::Config& config)
              d.tx, d.ty, d.tz,
              d.roll, d.pitch, d.yaw);
 
+    a.setCameraProfile(static_cast<CameraProfile>(d.cameraProfile));
+
     return Status_Ok;
 }
 
@@ -746,6 +748,8 @@ Status impl::setImageConfig(const image::Config& c)
     cmd.autoExposureRoiY         = c.autoExposureRoiY();
     cmd.autoExposureRoiWidth     = c.autoExposureRoiWidth();
     cmd.autoExposureRoiHeight    = c.autoExposureRoiHeight();
+
+    cmd.cameraProfile    = static_cast<uint32_t>(c.cameraProfile());
 
     return waitAck(cmd);
 }

--- a/source/LibMultiSense/details/wire/CamConfigMessage.h
+++ b/source/LibMultiSense/details/wire/CamConfigMessage.h
@@ -50,7 +50,7 @@ namespace wire {
 class CamConfig {
 public:
     static CRL_CONSTEXPR IdType      ID      = ID_DATA_CAM_CONFIG;
-    static CRL_CONSTEXPR VersionType VERSION = 5;
+    static CRL_CONSTEXPR VersionType VERSION = 6;
 
     //
     // Parameters representing the current camera configuration
@@ -101,6 +101,11 @@ public:
     uint16_t autoExposureRoiHeight;
 
     //
+    // Version 6 additions
+
+    uint32_t cameraProfile;
+
+    //
     // Constructors
 
     CamConfig(utility::BufferStreamReader&r, VersionType v) {serialize(r,v);};
@@ -135,7 +140,8 @@ public:
         autoExposureRoiX(0),
         autoExposureRoiY(0),
         autoExposureRoiWidth(crl::multisense::Roi_Full_Image),
-        autoExposureRoiHeight(crl::multisense::Roi_Full_Image)
+        autoExposureRoiHeight(crl::multisense::Roi_Full_Image),
+        cameraProfile(0)
         {};
 
     //
@@ -204,6 +210,15 @@ public:
             autoExposureRoiY = 0;
             autoExposureRoiWidth = crl::multisense::Roi_Full_Image;
             autoExposureRoiHeight = crl::multisense::Roi_Full_Image;
+        }
+
+        if (version >= 6)
+        {
+            message & cameraProfile;
+        }
+        else
+        {
+            cameraProfile = 0;
         }
     }
 };

--- a/source/LibMultiSense/details/wire/CamControlMessage.h
+++ b/source/LibMultiSense/details/wire/CamControlMessage.h
@@ -50,7 +50,7 @@ namespace wire {
 class CamControl {
 public:
     static CRL_CONSTEXPR IdType      ID      = ID_CMD_CAM_CONTROL;
-    static CRL_CONSTEXPR VersionType VERSION = 5;
+    static CRL_CONSTEXPR VersionType VERSION = 6;
 
     //
     // Parameters representing the current camera configuration
@@ -92,6 +92,11 @@ public:
     uint16_t autoExposureRoiY;
     uint16_t autoExposureRoiWidth;
     uint16_t autoExposureRoiHeight;
+
+    //
+    // Additions in version 6
+
+    uint32_t cameraProfile;
 
     //
     // Constructors
@@ -149,6 +154,15 @@ public:
             autoExposureRoiY = 0;
             autoExposureRoiWidth = crl::multisense::Roi_Full_Image;
             autoExposureRoiHeight = crl::multisense::Roi_Full_Image;
+        }
+
+        if (version >= 6)
+        {
+            message & cameraProfile;
+        }
+        else
+        {
+            cameraProfile = 0;
         }
     }
 };


### PR DESCRIPTION
This adds support for custom camera profiles. The default profile should do nothing, and allow the user to have full control over the camera. Each new profile will subsume the relevant user settings.  