### PR TITLE
Add image source associated with ROI exposure control

### DIFF
--- a/source/LibMultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/MultiSenseTypes.hh
@@ -749,12 +749,14 @@ public:
      * @param height The height of the ROI
      */
 
-    void setAutoExposureRoi(uint16_t start_x, uint16_t start_y, uint16_t width, uint16_t height)
+    void setAutoExposureRoi(uint16_t start_x, uint16_t start_y, uint16_t width, uint16_t height,
+                            const DataSource &imageSource = Source_Luma_Rectified_Left)
     {
         m_autoExposureRoiX = start_x;
         m_autoExposureRoiY = start_y;
         m_autoExposureRoiWidth = width;
         m_autoExposureRoiHeight = height;
+        m_autoExposureRoiImageSource = imageSource;
     }
 
     /**
@@ -962,6 +964,13 @@ public:
     uint16_t autoExposureRoiHeight   () const { return m_autoExposureRoiHeight; };
 
     /**
+     * Query the image source the auto exposure configuration is associated with
+     *
+     * @return Return the image source the auto exposure ROI is associated with
+     */
+    DataSource autoExposureRoiImageSource () const { return m_autoExposureRoiImageSource; };
+
+    /**
      * Query the current image configurations camera profile
      *
      * @return The current image configurations camera profile
@@ -1092,33 +1101,35 @@ public:
                m_hdrEnabled(false), m_storeSettingsInFlash(false),
                m_autoExposureRoiX(0), m_autoExposureRoiY(0),
                m_autoExposureRoiWidth(Roi_Full_Image), m_autoExposureRoiHeight(Roi_Full_Image),
+               m_autoExposureRoiImageSource(Source_Luma_Rectified_Left),
                m_profile(CameraProfile::USER_CONTROL),
                m_fx(0), m_fy(0), m_cx(0), m_cy(0),
                m_tx(0), m_ty(0), m_tz(0), m_roll(0), m_pitch(0), m_yaw(0) {};
 private:
 
-    float    m_fps, m_gain;
-    uint32_t m_exposure;
-    bool     m_aeEnabled;
-    uint32_t m_aeMax;
-    uint32_t m_aeDecay;
-    float    m_aeThresh;
-    float    m_wbBlue;
-    float    m_wbRed;
-    bool     m_wbEnabled;
-    uint32_t m_wbDecay;
-    float    m_wbThresh;
-    uint32_t m_width, m_height;
-    uint32_t m_disparities;
-    int      m_cam_mode;
-    int      m_offset;
-    float    m_spfStrength;
-    bool     m_hdrEnabled;
-    bool     m_storeSettingsInFlash;
-    uint16_t m_autoExposureRoiX;
-    uint16_t m_autoExposureRoiY;
-    uint16_t m_autoExposureRoiWidth;
-    uint16_t m_autoExposureRoiHeight;
+    float         m_fps, m_gain;
+    uint32_t      m_exposure;
+    bool          m_aeEnabled;
+    uint32_t      m_aeMax;
+    uint32_t      m_aeDecay;
+    float         m_aeThresh;
+    float         m_wbBlue;
+    float         m_wbRed;
+    bool          m_wbEnabled;
+    uint32_t      m_wbDecay;
+    float         m_wbThresh;
+    uint32_t      m_width, m_height;
+    uint32_t      m_disparities;
+    int           m_cam_mode;
+    int           m_offset;
+    float         m_spfStrength;
+    bool          m_hdrEnabled;
+    bool          m_storeSettingsInFlash;
+    uint16_t      m_autoExposureRoiX;
+    uint16_t      m_autoExposureRoiY;
+    uint16_t      m_autoExposureRoiWidth;
+    uint16_t      m_autoExposureRoiHeight;
+    DataSource    m_autoExposureRoiImageSource;
     CameraProfile m_profile;
 
 protected:

--- a/source/LibMultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/MultiSenseTypes.hh
@@ -144,6 +144,7 @@ static CRL_CONSTEXPR DataSource Source_Disparity_Aux          = (1U<<31);
  * to set the ROI to the full image regardless of the current resolution
  */
 static CRL_CONSTEXPR int Roi_Full_Image = 0;
+static CRL_CONSTEXPR DataSource Roi_Default_Source = Source_Luma_Left;
 
 #if __cplusplus > 199711L
 enum class CameraProfile
@@ -749,8 +750,32 @@ public:
      * @param height The height of the ROI
      */
 
+    void setAutoExposureRoi(uint16_t start_x, uint16_t start_y, uint16_t width, uint16_t height)
+    {
+        m_autoExposureRoiX = start_x;
+        m_autoExposureRoiY = start_y;
+        m_autoExposureRoiWidth = width;
+        m_autoExposureRoiHeight = height;
+    }
+
+    /**
+     * Set the desired ROI to use when computing the auto-exposure.
+     * x axis is horizontal and y axis is vertical.
+     * (0,0) coordinate starts in the upper left corner of the image.
+     * If (x + w > image width) or (y + h > image height) the sensor will return an error
+     * Setting to default:(0,0,crl::multisense::Roi_Full_Image,crl::multisense::Roi_Full_Image)
+     * will use the entire image for the ROI regardless of the current resolution
+     * This feature is only available in sensor firmware version 4.3 and greater
+     *
+     * @param start_x The X coordinate where the ROI starts
+     * @param start_y The Y coordinate where the ROI starts
+     * @param width The width of the ROI
+     * @param height The height of the ROI
+     * @param imageSource The image source the ROI parameters are associated with
+     */
+
     void setAutoExposureRoi(uint16_t start_x, uint16_t start_y, uint16_t width, uint16_t height,
-                            const DataSource &imageSource = Source_Luma_Rectified_Left)
+                            const DataSource &imageSource)
     {
         m_autoExposureRoiX = start_x;
         m_autoExposureRoiY = start_y;
@@ -1101,7 +1126,7 @@ public:
                m_hdrEnabled(false), m_storeSettingsInFlash(false),
                m_autoExposureRoiX(0), m_autoExposureRoiY(0),
                m_autoExposureRoiWidth(Roi_Full_Image), m_autoExposureRoiHeight(Roi_Full_Image),
-               m_autoExposureRoiImageSource(Source_Luma_Rectified_Left),
+               m_autoExposureRoiImageSource(Roi_Default_Source),
                m_profile(CameraProfile::USER_CONTROL),
                m_fx(0), m_fy(0), m_cx(0), m_cy(0),
                m_tx(0), m_ty(0), m_tz(0), m_roll(0), m_pitch(0), m_yaw(0) {};

--- a/source/LibMultiSense/details/channel.hh
+++ b/source/LibMultiSense/details/channel.hh
@@ -492,7 +492,6 @@ private:
 #endif
 };
 
-
 }}} // namespaces
 
 #endif // LibMultiSense_details_channel_hh

--- a/source/LibMultiSense/details/public.cc
+++ b/source/LibMultiSense/details/public.cc
@@ -695,7 +695,8 @@ Status impl::getImageConfig(image::Config& config)
     a.setHdr(d.hdrEnabled);
 
     a.setAutoExposureRoi(d.autoExposureRoiX, d.autoExposureRoiY,
-                         d.autoExposureRoiWidth, d.autoExposureRoiHeight);
+                         d.autoExposureRoiWidth, d.autoExposureRoiHeight,
+                         sourceWireToApi(d.autoExposureRoiImageSource));
 
     a.setCal(d.fx, d.fy, d.cx, d.cy,
              d.tx, d.ty, d.tz,
@@ -744,10 +745,11 @@ Status impl::setImageConfig(const image::Config& c)
     cmd.hdrEnabled               = c.hdrEnabled();
     cmd.storeSettingsInFlash     = c.storeSettingsInFlash();
 
-    cmd.autoExposureRoiX         = c.autoExposureRoiX();
-    cmd.autoExposureRoiY         = c.autoExposureRoiY();
-    cmd.autoExposureRoiWidth     = c.autoExposureRoiWidth();
-    cmd.autoExposureRoiHeight    = c.autoExposureRoiHeight();
+    cmd.autoExposureRoiX             = c.autoExposureRoiX();
+    cmd.autoExposureRoiY             = c.autoExposureRoiY();
+    cmd.autoExposureRoiWidth         = c.autoExposureRoiWidth();
+    cmd.autoExposureRoiHeight        = c.autoExposureRoiHeight();
+    cmd.autoExposureRoiImageSource   = sourceApiToWire(c.autoExposureRoiImageSource());
 
     cmd.cameraProfile    = static_cast<uint32_t>(c.cameraProfile());
 

--- a/source/LibMultiSense/details/wire/CamConfigMessage.h
+++ b/source/LibMultiSense/details/wire/CamConfigMessage.h
@@ -50,7 +50,7 @@ namespace wire {
 class CamConfig {
 public:
     static CRL_CONSTEXPR IdType      ID      = ID_DATA_CAM_CONFIG;
-    static CRL_CONSTEXPR VersionType VERSION = 6;
+    static CRL_CONSTEXPR VersionType VERSION = 7;
 
     //
     // Parameters representing the current camera configuration
@@ -106,6 +106,11 @@ public:
     uint32_t cameraProfile;
 
     //
+    // Additions in version 7
+
+    SourceType autoExposureRoiImageSource;
+
+    //
     // Constructors
 
     CamConfig(utility::BufferStreamReader&r, VersionType v) {serialize(r,v);};
@@ -141,7 +146,8 @@ public:
         autoExposureRoiY(0),
         autoExposureRoiWidth(crl::multisense::Roi_Full_Image),
         autoExposureRoiHeight(crl::multisense::Roi_Full_Image),
-        cameraProfile(0)
+        cameraProfile(0),
+        autoExposureRoiImageSource(SOURCE_LUMA_RECT_LEFT)
         {};
 
     //
@@ -219,6 +225,15 @@ public:
         else
         {
             cameraProfile = 0;
+        }
+
+        if (version >= 7)
+        {
+            message & autoExposureRoiImageSource;
+        }
+        else
+        {
+            autoExposureRoiImageSource = SOURCE_LUMA_RECT_LEFT;
         }
     }
 };

--- a/source/LibMultiSense/details/wire/CamConfigMessage.h
+++ b/source/LibMultiSense/details/wire/CamConfigMessage.h
@@ -51,6 +51,7 @@ class CamConfig {
 public:
     static CRL_CONSTEXPR IdType      ID      = ID_DATA_CAM_CONFIG;
     static CRL_CONSTEXPR VersionType VERSION = 7;
+    static CRL_CONSTEXPR SourceType Default_Roi_Source = SOURCE_LUMA_LEFT;
 
     //
     // Parameters representing the current camera configuration
@@ -147,7 +148,7 @@ public:
         autoExposureRoiWidth(crl::multisense::Roi_Full_Image),
         autoExposureRoiHeight(crl::multisense::Roi_Full_Image),
         cameraProfile(0),
-        autoExposureRoiImageSource(SOURCE_LUMA_RECT_LEFT)
+        autoExposureRoiImageSource(Default_Roi_Source)
         {};
 
     //
@@ -233,7 +234,7 @@ public:
         }
         else
         {
-            autoExposureRoiImageSource = SOURCE_LUMA_RECT_LEFT;
+            autoExposureRoiImageSource = Default_Roi_Source;
         }
     }
 };

--- a/source/LibMultiSense/details/wire/CamControlMessage.h
+++ b/source/LibMultiSense/details/wire/CamControlMessage.h
@@ -50,7 +50,7 @@ namespace wire {
 class CamControl {
 public:
     static CRL_CONSTEXPR IdType      ID      = ID_CMD_CAM_CONTROL;
-    static CRL_CONSTEXPR VersionType VERSION = 6;
+    static CRL_CONSTEXPR VersionType VERSION = 7;
 
     //
     // Parameters representing the current camera configuration
@@ -97,6 +97,11 @@ public:
     // Additions in version 6
 
     uint32_t cameraProfile;
+
+    //
+    // Additions in version 7
+
+    SourceType autoExposureRoiImageSource;
 
     //
     // Constructors
@@ -163,6 +168,15 @@ public:
         else
         {
             cameraProfile = 0;
+        }
+
+        if (version >= 7)
+        {
+            message & autoExposureRoiImageSource;
+        }
+        else
+        {
+            autoExposureRoiImageSource = SOURCE_LUMA_RECT_LEFT;
         }
     }
 };

--- a/source/LibMultiSense/details/wire/CamControlMessage.h
+++ b/source/LibMultiSense/details/wire/CamControlMessage.h
@@ -51,6 +51,7 @@ class CamControl {
 public:
     static CRL_CONSTEXPR IdType      ID      = ID_CMD_CAM_CONTROL;
     static CRL_CONSTEXPR VersionType VERSION = 7;
+    static CRL_CONSTEXPR SourceType Default_Roi_Source = SOURCE_LUMA_LEFT;
 
     //
     // Parameters representing the current camera configuration
@@ -176,7 +177,7 @@ public:
         }
         else
         {
-            autoExposureRoiImageSource = SOURCE_LUMA_RECT_LEFT;
+            autoExposureRoiImageSource = Default_Roi_Source;
         }
     }
 };


### PR DESCRIPTION
Add in the ability to specific the image source associated with the ROI exposure command. By default the Left Rectified image source is used. I am happy to update that assumption if anyone feels strongly about another default source. 