### PR TITLE
Add missing api to wire conversion functions

### DIFF
--- a/source/LibMultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/MultiSenseTypes.hh
@@ -959,7 +959,7 @@ public:
     void setPrimaryExposure (const ExposureConfig &c ) { m_primary_exposure = c; };
 
     /**
-     * Set the secondary exposures configurations. These are independent exposure configurations with
+     * Set the secondary exposures configurations. These are independent exposure configurations which
      * are used for alternate image streams. Secondary exposure configs will be subsumed
      * by the primary exposure configuration.
      *
@@ -1185,7 +1185,7 @@ public:
     ExposureConfig primaryExposure() const { return m_primary_exposure; };
 
     /**
-     * Query the collection of secondary exposures. These are independent exposure configurations with
+     * Query the collection of secondary exposures. These are independent exposure configurations which
      * are used for alternate image streams. Secondary exposure configs will be subsumed
      * by the primary exposure configuration
      *

--- a/source/LibMultiSense/details/public.cc
+++ b/source/LibMultiSense/details/public.cc
@@ -757,7 +757,7 @@ Status impl::getImageConfig(image::Config& config)
 
     a.setCameraProfile(static_cast<CameraProfile>(d.cameraProfile));
 
-    a.setExposureSource(d.exposureSource);
+    a.setExposureSource(sourceWireToApi(d.exposureSource));
 
     std::vector<image::ExposureConfig> secondaryExposures;
     for (size_t i = 0 ; i < d.secondaryExposureConfigs.size() ; ++i)
@@ -775,7 +775,7 @@ Status impl::getImageConfig(image::Config& config)
                              d.secondaryExposureConfigs[i].autoExposureRoiWidth,
                              d.secondaryExposureConfigs[i].autoExposureRoiHeight);
 
-        secondaryConfig.setExposureSource(d.secondaryExposureConfigs[i].exposureSource);
+        secondaryConfig.setExposureSource(sourceWireToApi(d.secondaryExposureConfigs[i].exposureSource));
 
         secondaryExposures.push_back(secondaryConfig);
     }
@@ -830,7 +830,7 @@ Status impl::setImageConfig(const image::Config& c)
 
     cmd.cameraProfile    = static_cast<uint32_t>(c.cameraProfile());
 
-    cmd.exposureSource = c.exposureSource();
+    cmd.exposureSource = sourceApiToWire(c.exposureSource());
 
     std::vector<image::ExposureConfig> secondaryExposures = c.secondaryExposures();
     std::vector<wire::ExposureConfig> secondaryConfigs;
@@ -849,7 +849,7 @@ Status impl::setImageConfig(const image::Config& c)
         secondaryConfig.autoExposureRoiWidth    = secondaryExposures[i].autoExposureRoiWidth();
         secondaryConfig.autoExposureRoiHeight   = secondaryExposures[i].autoExposureRoiHeight();
 
-        secondaryConfig.exposureSource = secondaryExposures[i].exposureSource();
+        secondaryConfig.exposureSource = sourceApiToWire(secondaryExposures[i].exposureSource());
 
         secondaryConfigs.push_back(secondaryConfig);
     }


### PR DESCRIPTION
Add missing api to wire conversion functions to convert to and from the exposure stream source types. 