### PR TITLE
Library Build Mode as Cmake Option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 endif()
 
 option (MULTISENSE_BUILD_UTILITIES "Build MultiSense utility applications. Defaults to ON for backwards compatibility." ON)
+option (BUILD_SHARED_LIBS "Build LibMultiSense as a shared library. Defaults to ON." ON)
 
 #
 # We want to build "Release" by default

--- a/source/LibMultiSense/CMakeLists.txt
+++ b/source/LibMultiSense/CMakeLists.txt
@@ -121,9 +121,9 @@ endif()
 # Add in all of the source files in this directory.
 #
 
-add_library(MultiSense SHARED ${MULTISENSE_HEADERS}
-                              ${DETAILS_HEADERS}
-                              ${DETAILS_SRC})
+add_library(MultiSense ${MULTISENSE_HEADERS}
+                       ${DETAILS_HEADERS}
+                       ${DETAILS_SRC})
 #
 # Versioning...someday lets automate this somehow
 #

--- a/source/LibMultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/MultiSenseTypes.hh
@@ -56,14 +56,18 @@
 // LibMultiSense when it is built as a DLL on Windows.
 #if !defined(MULTISENSE_API)
 #if defined (_MSC_VER)
-#if defined (MultiSense_EXPORTS)
+#if defined (MultiSense_STATIC)
+#define MULTISENSE_API __declspec(dllexport)
+#elif defined (MultiSense_EXPORTS)
 #define MULTISENSE_API __declspec(dllexport)
 #else
-#define MULTISENSE_API
+#define MULTISENSE_API __declspec(dllimport)
 #endif
+
 #else
 #define MULTISENSE_API
 #endif
+
 #endif
 
 #if defined (_MSC_VER)

--- a/source/LibMultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/MultiSenseTypes.hh
@@ -59,7 +59,7 @@
 #if defined (MultiSense_EXPORTS)
 #define MULTISENSE_API __declspec(dllexport)
 #else
-#define MULTISENSE_API __declspec(dllimport)
+#define MULTISENSE_API
 #endif
 #else
 #define MULTISENSE_API


### PR DESCRIPTION
Set library build mode as option, defaulting to shared. This makes it easier to link statically against libmultisense.