### PR TITLE
the secondary exposure roi was not getting through, traced it down.

### DIFF
--- a/source/LibMultiSense/details/public.cc
+++ b/source/LibMultiSense/details/public.cc
@@ -770,7 +770,7 @@ Status impl::getImageConfig(image::Config& config)
         secondaryConfig.setAutoExposureDecay(d.secondaryExposureConfigs[i].autoExposureDecay);
         secondaryConfig.setAutoExposureThresh(d.secondaryExposureConfigs[i].autoExposureThresh);
 
-        a.setAutoExposureRoi(d.secondaryExposureConfigs[i].autoExposureRoiX,
+        secondaryConfig.setAutoExposureRoi(d.secondaryExposureConfigs[i].autoExposureRoiX,
                              d.secondaryExposureConfigs[i].autoExposureRoiY,
                              d.secondaryExposureConfigs[i].autoExposureRoiWidth,
                              d.secondaryExposureConfigs[i].autoExposureRoiHeight);


### PR DESCRIPTION
Should have caught this in the review.
The secondary auto exposure roi's were not making it past getImageConfig.