### PR TITLE
ColorImageUtility: Enforce AutoWhiteBalance and AutoExposure to true

### DIFF
--- a/source/Utilities/ColorImageUtility/ColorImage.cc
+++ b/source/Utilities/ColorImageUtility/ColorImage.cc
@@ -401,6 +401,9 @@ int main(int    argc,
     }
     else {
         cfg.setFps(10.0);
+        cfg.setAutoWhiteBalance(true);
+        cfg.setAutoExposure(true);
+        cfg.setResolution(deviceInfo.imagerWidth / 2, deviceInfo.imagerHeight / 2);
         cfg.setResolution(deviceInfo.imagerWidth / 2, deviceInfo.imagerHeight / 2);
 
         status = channelP->ptr()->setImageConfig(cfg);

--- a/source/Utilities/ColorImageUtility/ColorImage.cc
+++ b/source/Utilities/ColorImageUtility/ColorImage.cc
@@ -404,7 +404,6 @@ int main(int    argc,
         cfg.setAutoWhiteBalance(true);
         cfg.setAutoExposure(true);
         cfg.setResolution(deviceInfo.imagerWidth / 2, deviceInfo.imagerHeight / 2);
-        cfg.setResolution(deviceInfo.imagerWidth / 2, deviceInfo.imagerHeight / 2);
 
         status = channelP->ptr()->setImageConfig(cfg);
         if (Status_Ok != status) {


### PR DESCRIPTION
Tested by rebooting camera and running image utility