### PR TITLE
Controls and public facing implementation for led synchronization

### DIFF
--- a/source/LibMultiSense/details/public.cc
+++ b/source/LibMultiSense/details/public.cc
@@ -728,6 +728,10 @@ Status impl::getLightingConfig(lighting::Config& c)
 
     c.setFlash(data.flash != 0);
 
+    c.setNumberOfPulses(data.number_of_pulses);
+
+    c.setLedStartupTime(data.led_delay_us);
+
     return Status_Ok;
 }
 
@@ -744,6 +748,10 @@ Status impl::setLightingConfig(const lighting::Config& c)
             msg.intensity[i] = static_cast<uint8_t> (255.0f * (utility::boundValue(duty, 0.0f, 100.0f) / 100.0f));
         }
     }
+
+    msg.led_delay_us = c.getStartupTime();
+
+    msg.number_of_pulses = c.getNumberOfPulses();
 
     return waitAck(msg);
 }

--- a/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
@@ -2052,15 +2052,60 @@ public:
     };
 
     /**
+    * Get the number of pulses of the light within a single exposure
+    *
+    * @return The current number of pulses
+    */
+    uint32_t getNumberOfPulses( ) const {
+      return m_numberPulses;
+    }
+
+    /**
+    * Set the number of pulses of the light within a single exposure
+    *
+    * @return True on success, False on failure
+    */
+    bool setNumberOfPulses( uint32_t numPulses) {
+
+      m_numberPulses = numPulses;
+      return true;
+    }
+
+    /**
+    * Get the startup time offset of the led in microseconds
+    *
+    * @return The current led startup time
+    */
+    uint32_t getStartupTime( ) const {
+      return m_lightStartupOffset_us;
+    }
+
+    /**
+    * Set the transient startup time of the led, for better synchronization.
+    *
+    * @param the led transient time.
+    *
+    * @return True on success, False on failure
+    */
+    bool setLedStartupTime( uint32_t ledTransientResponse_us) {
+
+      m_lightStartupOffset_us = ledTransientResponse_us;
+      return true;
+    }
+
+    /**
      * Default constructor. Flashing is disabled and all lights are off
      */
 
-    Config() : m_flashEnabled(false), m_dutyCycle(MAX_LIGHTS, -1.0f) {};
+    Config() : m_flashEnabled(false), m_dutyCycle(MAX_LIGHTS, -1.0f),
+               m_numberPulses(1), m_lightStartupOffset_us(0) {};
 
 private:
 
     bool               m_flashEnabled;
     std::vector<float> m_dutyCycle;
+    uint32_t           m_numberPulses;
+    uint32_t           m_lightStartupOffset_us;
 };
 
 /**

--- a/source/LibMultiSense/include/MultiSense/details/wire/LedSetMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/LedSetMessage.hh
@@ -50,7 +50,7 @@ namespace wire {
 class LedSet {
 public:
     static CRL_CONSTEXPR IdType      ID      = ID_CMD_LED_SET;
-    static CRL_CONSTEXPR VersionType VERSION = 1;
+    static CRL_CONSTEXPR VersionType VERSION = 2;
 
     //
     // Bit mask selecting which LEDs to update
@@ -68,10 +68,22 @@ public:
     uint8_t flash;
 
     //
+    // The delay of the LED from turning on to visible light seen in microseconds.
+    // Should be measured and specific to the LED in question.
+
+    uint32_t led_delay_us;
+
+    //
+    // For LED synchronized to shutter the number of pulses is how many pulses
+    // per exposure of an image.
+
+    uint32_t number_of_pulses;
+
+    //
     // Constructors
 
     LedSet(utility::BufferStreamReader&r, VersionType v) {serialize(r,v);};
-    LedSet() : mask(0), flash(0) {};
+    LedSet() : mask(0), flash(0), led_delay_us(0), number_of_pulses(1) {};
 
     //
     // Serialization routine
@@ -85,6 +97,17 @@ public:
         for(uint32_t i=0; i<lighting::MAX_LIGHTS; i++)
             archive & intensity[i];
         archive & flash;
+
+        if (version >= 2)
+        {
+          archive & led_delay_us;
+          archive & number_of_pulses;
+        }
+        else
+        {
+          led_delay_us = 0;
+          number_of_pulses = 1;
+        }
     }
 };
 

--- a/source/LibMultiSense/include/MultiSense/details/wire/LedStatusMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/LedStatusMessage.hh
@@ -50,7 +50,7 @@ namespace wire {
 class LedStatus {
 public:
     static CRL_CONSTEXPR IdType      ID      = ID_DATA_LED_STATUS;
-    static CRL_CONSTEXPR VersionType VERSION = 1;
+    static CRL_CONSTEXPR VersionType VERSION = 2;
 
     //
     // Bit mask indicating which LEDs are implemented
@@ -68,10 +68,22 @@ public:
     uint8_t flash;
 
     //
+    // The delay of the LED from turning on to visible light seen in microseconds.
+    // Should be measured and specific to the LED in question.
+
+    uint32_t led_delay_us;
+
+    //
+    // For LED synchronized to shutter the number of pulses is how many pulses
+    // per exposure of an image.
+
+    uint32_t number_of_pulses;
+
+    //
     // Constructors
 
     LedStatus(utility::BufferStreamReader&r, VersionType v) {serialize(r,v);};
-    LedStatus() : available(0), flash(0) {};
+    LedStatus() : available(0), flash(0), led_delay_us(0), number_of_pulses(1) {};
 
     //
     // Serialization routine
@@ -85,6 +97,17 @@ public:
         for(uint32_t i=0; i<lighting::MAX_LIGHTS; i++)
             message & intensity[i];
         message & flash;
+
+        if (version >= 2)
+        {
+          message & led_delay_us;
+          message & number_of_pulses;
+        }
+        else
+        {
+          led_delay_us = 0;
+          number_of_pulses = 1;
+        }
     }
 };
 


### PR DESCRIPTION
This pull request obsoletes https://github.com/carnegierobotics/LibMultiSense/pull/65
https://github.com/carnegierobotics/LibMultiSense/pull/65 Was made without signed commits, and a failed attempt to sign the commits after the PR was made, did not work in retroactively signing the commits.

Notes regarding the contents of the changes:

Controls required for the LED Sync to camera trigger.
The delay in microseconds is to be measured by recording when a digital signal is sent to an external LED, and when the light is registered on a photo detector.
The number of pulses is the amount of pulses that occur within an exposure cycle.
The typical led interface (duty cycle, availability) is still applicable. 