### PR TITLE
Add the ability to specify a cameraId for the remote head

### DIFF
--- a/source/LibMultiSense/details/channel.cc
+++ b/source/LibMultiSense/details/channel.cc
@@ -60,7 +60,7 @@ namespace details {
 //
 // Implementation constructor
 
-impl::impl(const std::string& address) :
+impl::impl(const std::string& address, uint32_t cameraId) :
     m_serverSocket(INVALID_SOCKET),
     m_serverSocketPort(0),
     m_sensorAddress(),
@@ -119,7 +119,7 @@ impl::impl(const std::string& address) :
     memset(&m_sensorAddress, 0, sizeof(m_sensorAddress));
 
     m_sensorAddress.sin_family = AF_INET;
-    m_sensorAddress.sin_port   = htons(DEFAULT_SENSOR_TX_PORT);
+    m_sensorAddress.sin_port   = htons(DEFAULT_SENSOR_TX_PORT + cameraId);
     m_sensorAddress.sin_addr   = addr;
 
     //
@@ -660,7 +660,20 @@ Channel* Channel::Create(const std::string& address)
 {
     try {
 
-        return new details::impl(address);
+        return new details::impl(address, 0);
+
+    } catch (const std::exception& e) {
+
+        CRL_DEBUG("exception: %s\n", e.what());
+        return NULL;
+    }
+}
+
+Channel* Channel::Create(const std::string& address, uint32_t cameraId)
+{
+    try {
+
+        return new details::impl(address, cameraId);
 
     } catch (const std::exception& e) {
 

--- a/source/LibMultiSense/details/channel.cc
+++ b/source/LibMultiSense/details/channel.cc
@@ -451,19 +451,22 @@ DataSource impl::sourceWireToApi(wire::SourceType mask)
 uint32_t impl::hardwareApiToWire(uint32_t a)
 {
     switch(a) {
-    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_SL:          return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_SL;
-    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_S7:          return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_S7;
-    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_M:           return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_M;
-    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_S7S:         return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_S7S;
-    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_S21:         return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_S21;
-    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_ST21:        return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_ST21;
-    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_C6S2_S27:    return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_C6S2_S27;
-    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_S30:         return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_S30;
-    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_S7AR:        return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_S7AR;
-    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_KS21:        return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_KS21;
-    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_MONOCAM:     return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_MONOCAM;
-    case system::DeviceInfo::HARDWARE_REV_BCAM:                   return wire::SysDeviceInfo::HARDWARE_REV_BCAM;
-    case system::DeviceInfo::HARDWARE_REV_MONO:                   return wire::SysDeviceInfo::HARDWARE_REV_MONO;
+    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_SL:                  return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_SL;
+    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_S7:                  return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_S7;
+    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_M:                   return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_M;
+    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_S7S:                 return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_S7S;
+    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_S21:                 return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_S21;
+    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_ST21:                return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_ST21;
+    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_C6S2_S27:            return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_C6S2_S27;
+    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_S30:                 return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_S30;
+    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_S7AR:                return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_S7AR;
+    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_KS21:                return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_KS21;
+    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_MONOCAM:             return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_MONOCAM;
+    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_REMOTE_HEAD_VPB:     return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_REMOTE_HEAD_VPB;
+    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_REMOTE_HEAD_STEREO:  return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_REMOTE_HEAD_STEREO;
+    case system::DeviceInfo::HARDWARE_REV_MULTISENSE_REMOTE_HEAD_MONOCAM: return wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_REMOTE_HEAD_MONOCAM;
+    case system::DeviceInfo::HARDWARE_REV_BCAM:                           return wire::SysDeviceInfo::HARDWARE_REV_BCAM;
+    case system::DeviceInfo::HARDWARE_REV_MONO:                           return wire::SysDeviceInfo::HARDWARE_REV_MONO;
     default:
         CRL_DEBUG("unknown API hardware type \"%d\"\n", a);
         return a; // pass through
@@ -472,19 +475,22 @@ uint32_t impl::hardwareApiToWire(uint32_t a)
 uint32_t impl::hardwareWireToApi(uint32_t w)
 {
     switch(w) {
-    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_SL:       return system::DeviceInfo::HARDWARE_REV_MULTISENSE_SL;
-    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_S7:       return system::DeviceInfo::HARDWARE_REV_MULTISENSE_S7;
-    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_M:        return system::DeviceInfo::HARDWARE_REV_MULTISENSE_M;
-    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_S7S:      return system::DeviceInfo::HARDWARE_REV_MULTISENSE_S7S;
-    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_S21:      return system::DeviceInfo::HARDWARE_REV_MULTISENSE_S21;
-    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_ST21:     return system::DeviceInfo::HARDWARE_REV_MULTISENSE_ST21;
-    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_C6S2_S27: return system::DeviceInfo::HARDWARE_REV_MULTISENSE_C6S2_S27;
-    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_S30:      return system::DeviceInfo::HARDWARE_REV_MULTISENSE_S30;
-    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_S7AR:     return system::DeviceInfo::HARDWARE_REV_MULTISENSE_S7AR;
-    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_KS21:     return system::DeviceInfo::HARDWARE_REV_MULTISENSE_KS21;
-    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_MONOCAM:  return system::DeviceInfo::HARDWARE_REV_MULTISENSE_MONOCAM;
-    case wire::SysDeviceInfo::HARDWARE_REV_BCAM:                return system::DeviceInfo::HARDWARE_REV_BCAM;
-    case wire::SysDeviceInfo::HARDWARE_REV_MONO:                return system::DeviceInfo::HARDWARE_REV_MONO;
+    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_SL:                  return system::DeviceInfo::HARDWARE_REV_MULTISENSE_SL;
+    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_S7:                  return system::DeviceInfo::HARDWARE_REV_MULTISENSE_S7;
+    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_M:                   return system::DeviceInfo::HARDWARE_REV_MULTISENSE_M;
+    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_S7S:                 return system::DeviceInfo::HARDWARE_REV_MULTISENSE_S7S;
+    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_S21:                 return system::DeviceInfo::HARDWARE_REV_MULTISENSE_S21;
+    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_ST21:                return system::DeviceInfo::HARDWARE_REV_MULTISENSE_ST21;
+    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_C6S2_S27:            return system::DeviceInfo::HARDWARE_REV_MULTISENSE_C6S2_S27;
+    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_S30:                 return system::DeviceInfo::HARDWARE_REV_MULTISENSE_S30;
+    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_S7AR:                return system::DeviceInfo::HARDWARE_REV_MULTISENSE_S7AR;
+    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_KS21:                return system::DeviceInfo::HARDWARE_REV_MULTISENSE_KS21;
+    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_MONOCAM:             return system::DeviceInfo::HARDWARE_REV_MULTISENSE_MONOCAM;
+    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_REMOTE_HEAD_VPB:     return system::DeviceInfo::HARDWARE_REV_MULTISENSE_REMOTE_HEAD_VPB;
+    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_REMOTE_HEAD_STEREO:  return system::DeviceInfo::HARDWARE_REV_MULTISENSE_REMOTE_HEAD_STEREO;
+    case wire::SysDeviceInfo::HARDWARE_REV_MULTISENSE_REMOTE_HEAD_MONOCAM: return system::DeviceInfo::HARDWARE_REV_MULTISENSE_REMOTE_HEAD_MONOCAM;
+    case wire::SysDeviceInfo::HARDWARE_REV_BCAM:                           return system::DeviceInfo::HARDWARE_REV_BCAM;
+    case wire::SysDeviceInfo::HARDWARE_REV_MONO:                           return system::DeviceInfo::HARDWARE_REV_MONO;
     default:
         CRL_DEBUG("unknown WIRE hardware type \"%d\"\n", w);
         return w; // pass through

--- a/source/LibMultiSense/details/channel.cc
+++ b/source/LibMultiSense/details/channel.cc
@@ -669,7 +669,7 @@ Channel* Channel::Create(const std::string& address)
     }
 }
 
-Channel* Channel::Create(const std::string& address, uint32_t cameraId)
+Channel* Channel::Create(const std::string& address, const RemoteHeadChannel cameraId)
 {
     try {
 

--- a/source/LibMultiSense/details/channel.cc
+++ b/source/LibMultiSense/details/channel.cc
@@ -60,7 +60,7 @@ namespace details {
 //
 // Implementation constructor
 
-impl::impl(const std::string& address, uint32_t cameraId) :
+impl::impl(const std::string& address, const RemoteHeadChannel &cameraId) :
     m_serverSocket(INVALID_SOCKET),
     m_serverSocketPort(0),
     m_sensorAddress(),
@@ -675,7 +675,7 @@ Channel* Channel::Create(const std::string& address)
     }
 }
 
-Channel* Channel::Create(const std::string& address, const RemoteHeadChannel cameraId)
+Channel* Channel::Create(const std::string& address, const RemoteHeadChannel &cameraId)
 {
     try {
 

--- a/source/LibMultiSense/include/MultiSense/MultiSenseChannel.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseChannel.hh
@@ -96,7 +96,7 @@ public:
      * return A pointer to a new Channel instance
      */
 
-    static Channel* Create(const std::string& sensorAddress, uint32_t cameraId);
+    static Channel* Create(const std::string& sensorAddress, const RemoteHeadChannel &cameraId);
 
     /**
      * Destroy a channel instance that was created using the static

--- a/source/LibMultiSense/include/MultiSense/MultiSenseChannel.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseChannel.hh
@@ -83,6 +83,22 @@ public:
     static Channel* Create(const std::string& sensorAddress);
 
     /**
+     * Create a Channel instance, used to manage all communications
+     * with a sensor.  The resulting pointer must be explicitly
+     * destroyed using the static member function Channel::Destroy().
+     *
+     * @param sensorAddress The device IPv4 address which can be a dotted-quad,
+     * or any hostname resolvable by gethostbyname().
+     * @param cameraId The ID of the remote camera to connect to. This is used for
+     * newer remote head based systems which have multiple stereo cameras
+     * connected to a single FPGA for stereo processing
+     *
+     * return A pointer to a new Channel instance
+     */
+
+    static Channel* Create(const std::string& sensorAddress, uint32_t cameraId);
+
+    /**
      * Destroy a channel instance that was created using the static
      * member function Channel::Create(). This operation should be
      * done before exiting

--- a/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
@@ -189,6 +189,29 @@ typedef uint32_t ImageCompressionCodec;
 static CRL_CONSTEXPR ImageCompressionCodec H264 = 0;
 
 /**
+ * Remote head channel defines which channel is used to communicate to a
+ * specific component in the Remote Head system.
+ * The possible components are:
+ * Remote_Head_VPB The Remote Head Vision Processor Board.
+ * Remote_Head_0   The Remote Head Camera located in position 0
+ * Remote_Head_1   The Remote Head Camera located in position 1
+ * Remote_Head_2   The Remote Head Camera located in position 2
+ * Remote_Head_3   The Remote Head Camera located in position 3
+ */
+typedef uint32_t RemoteHeadChannel;
+/** The Remote Head Vision Processor Board */
+static CRL_CONSTEXPR RemoteHeadChannel Remote_Head_VPB = 0;
+/** The Remote Head Camera at position 0*/
+static CRL_CONSTEXPR RemoteHeadChannel Remote_Head_0   = 1;
+/** The Remote Head Camera at position 1*/
+static CRL_CONSTEXPR RemoteHeadChannel Remote_Head_1   = 2;
+/** The Remote Head Camera at position 2*/
+static CRL_CONSTEXPR RemoteHeadChannel Remote_Head_2   = 3;
+/** The Remote Head Camera at position 3*/
+static CRL_CONSTEXPR RemoteHeadChannel Remote_Head_3   = 4;
+
+
+/**
  * Class used to request that MultiSense data be sent to a 3rd-party
  * stream destination (UDP port), currently supported only by CRL's
  * Monocular IP Camera.  This functionality is not supported by any of
@@ -2764,20 +2787,23 @@ public:
     /** The maximum number of PCBs in a device */
     static CRL_CONSTEXPR uint8_t MAX_PCBS                   = 8;
 
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_SL       = 1;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_S7       = 2;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_S        = HARDWARE_REV_MULTISENSE_S7; // alias for backward source compatibility
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_M        = 3;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_S7S      = 4;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_S21      = 5;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_ST21     = 6;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_C6S2_S27 = 7;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_S30      = 8;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_S7AR     = 9;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_KS21     = 10;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_MONOCAM  = 11;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_BCAM                = 100;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MONO                = 101;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_SL                  = 1;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_S7                  = 2;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_S                   = HARDWARE_REV_MULTISENSE_S7; // alias for backward source compatibility
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_M                   = 3;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_S7S                 = 4;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_S21                 = 5;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_ST21                = 6;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_C6S2_S27            = 7;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_S30                 = 8;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_S7AR                = 9;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_KS21                = 10;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_MONOCAM             = 11;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_REMOTE_HEAD_VPB     = 12;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_REMOTE_HEAD_STEREO  = 13;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_REMOTE_HEAD_MONOCAM = 14;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_BCAM                           = 100;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MONO                           = 101;
 
     static CRL_CONSTEXPR uint32_t IMAGER_TYPE_CMV2000_GREY   = 1;
     static CRL_CONSTEXPR uint32_t IMAGER_TYPE_CMV2000_COLOR  = 2;

--- a/source/LibMultiSense/include/MultiSense/details/channel.hh
+++ b/source/LibMultiSense/include/MultiSense/details/channel.hh
@@ -93,7 +93,7 @@ public:
     //
     // Construction
 
-    impl(const std::string& address, uint32_t cameraId);
+    impl(const std::string& address, const RemoteHeadChannel &cameraId);
     ~impl();
 
     //

--- a/source/LibMultiSense/include/MultiSense/details/channel.hh
+++ b/source/LibMultiSense/include/MultiSense/details/channel.hh
@@ -93,7 +93,7 @@ public:
     //
     // Construction
 
-    impl(const std::string& address);
+    impl(const std::string& address, uint32_t cameraId);
     ~impl();
 
     //

--- a/source/LibMultiSense/include/MultiSense/details/wire/SysDeviceInfoMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/SysDeviceInfoMessage.hh
@@ -87,19 +87,22 @@ public:
         return MAX_PCBS;
     }
 
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_SL       = 1;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_S7       = 2;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_M        = 3;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_S7S      = 4;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_S21      = 5;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_ST21     = 6;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_C6S2_S27 = 7;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_S30      = 8;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_S7AR     = 9;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_KS21     = 10;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_MONOCAM  = 11;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_BCAM                = 100;
-    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MONO                = 101;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_SL                  = 1;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_S7                  = 2;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_M                   = 3;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_S7S                 = 4;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_S21                 = 5;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_ST21                = 6;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_C6S2_S27            = 7;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_S30                 = 8;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_S7AR                = 9;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_KS21                = 10;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_MONOCAM             = 11;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_REMOTE_HEAD_VPB     = 12;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_REMOTE_HEAD_STEREO  = 13;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MULTISENSE_REMOTE_HEAD_MONOCAM = 14;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_BCAM                           = 100;
+    static CRL_CONSTEXPR uint32_t HARDWARE_REV_MONO                           = 101;
 
     static CRL_CONSTEXPR uint32_t IMAGER_TYPE_CMV2000_GREY   = 1;
     static CRL_CONSTEXPR uint32_t IMAGER_TYPE_CMV2000_COLOR  = 2;

--- a/source/Utilities/ImageCalUtility/ImageCalUtility.cc
+++ b/source/Utilities/ImageCalUtility/ImageCalUtility.cc
@@ -70,7 +70,7 @@ void usage(const char *programNameP)
     fprintf(stderr, "Where <options> are:\n");
     fprintf(stderr, "\t-a <ip_address>      : ip address (default=10.66.171.21)\n");
     fprintf(stderr, "\t-s                   : set the calibration (default is query)\n");
-    fprintf(stderr, "\t-r                   : apply calibration to remote head\n");
+    fprintf(stderr, "\t-r                   : remote head channel (options: VPB, 0, 1, 2, 3)\n");
     fprintf(stderr, "\t-y                   : disable confirmation prompts\n");
 
     exit(-1);
@@ -86,25 +86,25 @@ static int getRemoteHeadIdFromString(const std::string &head_str, RemoteHeadChan
 {
   int err = 0;
 
-  if (head_str == "Remote_Head_VPB")
-    rh = Remote_Head_VPB;
-  else if (head_str == "Remote_Head_0")
-    rh = Remote_Head_0;
-  else if (head_str == "Remote_Head_1")
-    rh = Remote_Head_1;
-  else if (head_str == "Remote_Head_2")
-    rh = Remote_Head_2;
-  else if (head_str == "Remote_Head_3")
-    rh = Remote_Head_3;
+  if (head_str == "VPB")
+      rh = Remote_Head_VPB;
+  else if (head_str == "0")
+      rh = Remote_Head_0;
+  else if (head_str == "1")
+      rh = Remote_Head_1;
+  else if (head_str == "2")
+      rh = Remote_Head_2;
+  else if (head_str == "3")
+      rh = Remote_Head_3;
   else {
-    std::cerr << "Error: Unrecognized remote head" << '\n';
-    std::cerr << "Please use one of the following:" << '\n';
-    std::cerr << "\tRemote_Head_VPB" << '\n';
-    std::cerr << "\tRemote_Head_0" << '\n';
-    std::cerr << "\tRemote_Head_1" << '\n';
-    std::cerr << "\tRemote_Head_2" << '\n';
-    std::cerr << "\tRemote_Head_3" << '\n';
-    err = -1;
+       std::cerr << "Error: Unrecognized remote head" << '\n';
+       std::cerr << "Please use one of the following:" << '\n';
+       std::cerr << "\tVPB" << '\n';
+       std::cerr << "\t0" << '\n';
+       std::cerr << "\t1" << '\n';
+       std::cerr << "\t2" << '\n';
+       std::cerr << "\t3" << '\n';
+       err = -1;
   }
 
   return err;
@@ -166,10 +166,10 @@ int main(int    argc,
         case 'i': intrinsicsFile = std::string(optarg);    break;
         case 'e': extrinsicsFile = std::string(optarg);    break;
         case 'r': {
-            remoteHeadChannelId = std::string(optarg);
-            cameraRemoteHead = true;
-          }
-          break;
+              remoteHeadChannelId = std::string(optarg);
+              cameraRemoteHead = true;
+              break;
+        }
         case 's': setCal         = true;                   break;
         case 'y': prompt         = false;                  break;
         default: usage(*argvPP);                           break;
@@ -213,15 +213,15 @@ int main(int    argc,
     // Initialize communications.
     Channel *channelP = NULL;
     if (cameraRemoteHead) {
-      RemoteHeadChannel rch;
-      if (getRemoteHeadIdFromString(remoteHeadChannelId, rch) < 0)
-      {
-        return -1;
-      }
-      channelP = Channel::Create(ipAddress, rch);
+        RemoteHeadChannel rch;
+        if (getRemoteHeadIdFromString(remoteHeadChannelId, rch) < 0) {
+            return -1;
+        }
+        channelP = Channel::Create(ipAddress, rch);
     }
-    else
-      channelP = Channel::Create(ipAddress);
+    else {
+        channelP = Channel::Create(ipAddress);
+    }
 
     if (NULL == channelP) {
     	fprintf(stderr, "Failed to establish communications with \"%s\"\n",


### PR DESCRIPTION
Initial support for the remote head by specifying a cameraId when creating a channel connection.

This has been tested with a legacy S21, but needs firmware updates to listen for commands on ports 9001, 9002, 9003, and 9004.