### PR TITLE
Support monotonic system time. Handle large time jumps from issue #76

### DIFF
--- a/source/LibMultiSense/CMakeLists.txt
+++ b/source/LibMultiSense/CMakeLists.txt
@@ -10,6 +10,7 @@ include(CheckFunctionExists)
 
 check_function_exists(vasprintf HAVE_VASPRINTF)
 
+option (MULTISENSE_USE_MONOTONIC_CLOCK "Build LibMultiSense to use CLOCK_MONOTONIC for network time sync. Defaults to OFF." OFF)
 option(MULTISENSE_INSTALL_WIRE_PROTOCOL "Install low level wire headers, for integration with external event systems" OFF)
 
 #
@@ -125,6 +126,10 @@ endif()
 add_library(MultiSense ${MULTISENSE_HEADERS}
                        ${DETAILS_HEADERS}
                        ${DETAILS_SRC})
+
+if (MULTISENSE_USE_MONOTONIC_CLOCK)
+    target_compile_definitions(MultiSense PRIVATE USE_MONOTONIC_CLOCK=${MULTISENSE_USE_MONOTONIC_CLOCK})
+endif()
 #
 # Versioning...someday lets automate this somehow
 #

--- a/source/LibMultiSense/details/channel.cc
+++ b/source/LibMultiSense/details/channel.cc
@@ -536,7 +536,15 @@ void impl::applySensorTimeOffset(const utility::TimeStamp& offset)
 {
     utility::ScopedLock lock(m_timeLock);
 
-    if (false == m_timeOffsetInit) {
+    //
+    // Reseed on startup or if there is a large jump in time
+    //
+    CRL_CONSTEXPR int TIME_SYNC_THRESH_SECONDS = 100;
+    const bool seed_offset = (false == m_timeOffsetInit) ||
+                             (abs(m_timeOffset.getSeconds() - offset.getSeconds()) > TIME_SYNC_THRESH_SECONDS);
+
+    if (seed_offset)
+    {
         m_timeOffset = offset; // seed
         m_timeOffsetInit = true;
         return;

--- a/source/LibMultiSense/details/utility/TimeStamp.cc
+++ b/source/LibMultiSense/details/utility/TimeStamp.cc
@@ -40,6 +40,7 @@
  **/
 
 #include "MultiSense/details/utility/TimeStamp.hh"
+#include "MultiSense/details/utility/Exception.hh"
 
 #ifndef WIN32
 #include <sys/time.h>
@@ -198,7 +199,22 @@ TimeStamp TimeStamp::getCurrentTime()
     timeStamp.time.tv_usec = static_cast<long> ((currentTimeAsLargeInteger.QuadPart - static_cast<int64_t>(timeStamp.time.tv_sec) * 10000000) / 10);
 
 #else
+
+#if defined (USE_MONOTONIC_CLOCK)
+    struct timespec ts;
+    ts.tv_sec = 0;
+    ts.tv_nsec = 0;
+
+    if (0 != clock_gettime(CLOCK_MONOTONIC, &ts))
+    {
+        CRL_EXCEPTION("Failed to call clock_gettime().");
+    }
+
+    TIMESPEC_TO_TIMEVAL(&timeStamp.time, &ts);
+#else
     gettimeofday(&timeStamp.time, 0);
+#endif
+
 #endif
 
     return timeStamp;


### PR DESCRIPTION
Resolves #76. Adds support for monotonic system time. Tested locally on a S27