### PR TITLE
Fix warnings raised by the MSVC compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ docs/latex/
 *.exe
 *.out
 *.app
+
+# Visual Studio cache/options directory
+.vs

--- a/source/LibMultiSense/details/channel.cc
+++ b/source/LibMultiSense/details/channel.cc
@@ -119,7 +119,7 @@ impl::impl(const std::string& address, const RemoteHeadChannel &cameraId) :
     memset(&m_sensorAddress, 0, sizeof(m_sensorAddress));
 
     m_sensorAddress.sin_family = AF_INET;
-    m_sensorAddress.sin_port   = htons(DEFAULT_SENSOR_TX_PORT + static_cast<uint32_t>(cameraId + 1));
+    m_sensorAddress.sin_port   = htons(DEFAULT_SENSOR_TX_PORT + static_cast<uint16_t>(cameraId + 1));
     m_sensorAddress.sin_addr   = addr;
 
     //

--- a/source/LibMultiSense/details/dispatch.cc
+++ b/source/LibMultiSense/details/dispatch.cc
@@ -505,9 +505,9 @@ void impl::dispatch(utility::BufferStreamWriter& buffer)
         header.numDetections = apriltag.numDetections;
 
         // Loop over detections and convert from wire to header type
-        for (size_t i = 0 ; i < apriltag.detections.size() ; ++i)
+        for (size_t index = 0 ; index < apriltag.detections.size() ; ++index)
         {
-            const wire::ApriltagDetection incoming = apriltag.detections[i];
+            const wire::ApriltagDetection incoming = apriltag.detections[index];
 
             apriltag::Header::ApriltagDetection outgoing;
 

--- a/source/LibMultiSense/details/dispatch.cc
+++ b/source/LibMultiSense/details/dispatch.cc
@@ -505,9 +505,8 @@ void impl::dispatch(utility::BufferStreamWriter& buffer)
         header.numDetections = apriltag.numDetections;
 
         // Loop over detections and convert from wire to header type
-        for (size_t i = 0 ; i < apriltag.detections.size() ; ++i)
+        for (const wire::ApriltagDetection& incoming : apriltag.detections)
         {
-            const wire::ApriltagDetection incoming = apriltag.detections[i];
             apriltag::Header::ApriltagDetection outgoing;
 
             outgoing.family = std::string(incoming.family);

--- a/source/LibMultiSense/details/dispatch.cc
+++ b/source/LibMultiSense/details/dispatch.cc
@@ -505,8 +505,10 @@ void impl::dispatch(utility::BufferStreamWriter& buffer)
         header.numDetections = apriltag.numDetections;
 
         // Loop over detections and convert from wire to header type
-        for (const wire::ApriltagDetection& incoming : apriltag.detections)
+        for (size_t i = 0 ; i < apriltag.detections.size() ; ++i)
         {
+            const wire::ApriltagDetection incoming = apriltag.detections[i];
+
             apriltag::Header::ApriltagDetection outgoing;
 
             outgoing.family = std::string(incoming.family);

--- a/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
@@ -201,7 +201,7 @@ static CRL_CONSTEXPR ImageCompressionCodec H264 = 0;
  * Remote_Head_2   The Remote Head Camera located in position 2
  * Remote_Head_3   The Remote Head Camera located in position 3
  */
-typedef int32_t RemoteHeadChannel;
+typedef int16_t RemoteHeadChannel;
 /** The Remote Head Vision Processor Board */
 static CRL_CONSTEXPR RemoteHeadChannel Remote_Head_VPB = -1;
 /** The Remote Head Camera at position 0*/

--- a/source/Utilities/RectifiedFocalLengthUtility/RectifiedFocalLengthUtility.cc
+++ b/source/Utilities/RectifiedFocalLengthUtility/RectifiedFocalLengthUtility.cc
@@ -155,19 +155,19 @@ int main(int    argc,
 
         tx = calibration.right.P[0][3] / calibration.right.P[0][0];
 
-        calibration.left.P[0][0]  = rectifiedFocalLength;
-        calibration.left.P[1][1]  = rectifiedFocalLength;
-        calibration.right.P[0][0] = rectifiedFocalLength;
-        calibration.right.P[1][1] = rectifiedFocalLength;
-        calibration.right.P[0][3] = rectifiedFocalLength * tx;
+        calibration.left.P[0][0]  = static_cast<float> (rectifiedFocalLength);
+        calibration.left.P[1][1]  = static_cast<float> (rectifiedFocalLength);
+        calibration.right.P[0][0] = static_cast<float> (rectifiedFocalLength);
+        calibration.right.P[1][1] = static_cast<float> (rectifiedFocalLength);
+        calibration.right.P[0][3] = static_cast<float> (rectifiedFocalLength * tx);
 
         if (hasAuxCamera) {
 
             auxTx = calibration.aux.P[0][3] / calibration.aux.P[0][0];
 
-            calibration.aux.P[0][0] = rectifiedFocalLength;
-            calibration.aux.P[1][1] = rectifiedFocalLength;
-            calibration.aux.P[0][3] = rectifiedFocalLength * auxTx;
+            calibration.aux.P[0][0] = static_cast<float> (rectifiedFocalLength);
+            calibration.aux.P[1][1] = static_cast<float> (rectifiedFocalLength);
+            calibration.aux.P[0][3] = static_cast<float> (rectifiedFocalLength * auxTx);
         }
 
         status = channelP->setImageCalibration(calibration);


### PR DESCRIPTION
MSVC raises some legitimate C++ warnings that aren't flagged by GCC. This PR address those warnings.

This code builds successfully under VS2019, VS2022, and GCC 7.4 (Ubuntu 18)