### PR TITLE
Bind to network adapter

### DIFF
--- a/source/LibMultiSense/details/channel.cc
+++ b/source/LibMultiSense/details/channel.cc
@@ -311,7 +311,11 @@ void impl::bind(const std::string &ifName)
                               strerror(errno));
             }
         }
+    #else
+        if (!ifName.empty())
+            CRL_DEBUG("User specified binding to adapter '%s', but this feature is only supported under linux. Ignoring..", ifName.c_str())
     #endif
+
     //
     // Turn non-blocking on.
 #if WIN32

--- a/source/LibMultiSense/include/MultiSense/MultiSenseChannel.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseChannel.hh
@@ -97,6 +97,35 @@ public:
      */
 
     static Channel* Create(const std::string& sensorAddress, const RemoteHeadChannel &cameraId);
+    /**
+     * @note (Linux only!)
+     * Create a Channel instance, used to manage all communications
+     * with a sensor.  The resulting pointer must be explicitly
+     * destroyed using the static member function Channel::Destroy().
+     *
+     * @param sensorAddress The device IPv4 address which can be a dotted-quad,
+     * or any hostname resolvable by gethostbyname().
+     * @param interfaceName The name of the network interface to bind to using the SO_BINDTODEVICE option
+     * @return A pointer to a new Channel instance
+     */
+    static Channel* Create(const std::string &sensorAddress,  const std::string &interfaceName);
+
+    /**
+     * @note (Linux only!)
+     * Create a Channel instance, used to manage all communications
+     * with a sensor.  The resulting pointer must be explicitly
+     * destroyed using the static member function Channel::Destroy().
+     *
+     * @param sensorAddress The device IPv4 address which can be a dotted-quad,
+     * or any hostname resolvable by gethostbyname().
+     * @param cameraId The ID of the remote camera to connect to. This is used for
+     * newer remote head based systems which have multiple stereo cameras
+     * connected to a single FPGA for stereo processing
+     * @param interfaceName The name of the network interface to bind to use for this connection.
+     * Set using the socket option SO_BINDTODEVICE
+     * @return A pointer to a new Channel instance
+     */
+    static Channel* Create(const std::string &sensorAddress, const RemoteHeadChannel &cameraId, const std::string &interfaceName);
 
     /**
      * Destroy a channel instance that was created using the static

--- a/source/LibMultiSense/include/MultiSense/details/channel.hh
+++ b/source/LibMultiSense/include/MultiSense/details/channel.hh
@@ -94,7 +94,7 @@ public:
     //
     // Construction
 
-    impl(const std::string& address, const RemoteHeadChannel &cameraId);
+    impl(const std::string& address, const RemoteHeadChannel &cameraId, const std::string& ifName);
     ~impl();
 
     //
@@ -560,7 +560,7 @@ private:
                                                        uint32_t&     microseconds);
 
     void                         cleanup();
-    void                         bind   ();
+    void                         bind   (const std::string& ifName);
     void                         handle ();
 
     //


### PR DESCRIPTION
Binding a socket to a specific network adapter on Linux.
Added two new constructors to specify a interfaceName string for both multisense and remotehead, and passing the interfacename as an argument to the bind() function.
Setting SO_BINDTODEVICE has to happen before ::bind() and after the socket descriptor is created.

