### PR TITLE
Update from 4.3.0 to 6.0.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 
 cmake_minimum_required(VERSION 3.1)
 
-set(CPACK_PACKAGE_VERSION "4.3.0")
+set(CPACK_PACKAGE_VERSION "6.0.0")
 
 if (${CMAKE_VERSION} VERSION_LESS "3.12")
     project(LibMultiSense

--- a/VERSION.TXT
+++ b/VERSION.TXT
@@ -1,1 +1,1 @@
-This is the MultiSense API version 4.3.0
+This is the MultiSense API version 6.0.0

--- a/source/LibMultiSense/CMakeLists.txt
+++ b/source/LibMultiSense/CMakeLists.txt
@@ -136,7 +136,7 @@ endif()
 #
 # Versioning...someday lets automate this somehow
 #
-set(version "4.3.0")
+set(version "6.0.0")
 set_target_properties(MultiSense PROPERTIES VERSION "${version}")
 
 target_include_directories(MultiSense PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)

--- a/source/LibMultiSense/include/MultiSense/details/channel.hh
+++ b/source/LibMultiSense/include/MultiSense/details/channel.hh
@@ -266,7 +266,7 @@ private:
     //
     // The version of this API
 
-    static CRL_CONSTEXPR VersionType API_VERSION = 0x0403; // 4.3
+    static CRL_CONSTEXPR VersionType API_VERSION = 0x0600; // 6.0
 
     //
     // Misc. internal constants


### PR DESCRIPTION
Officially release the new aux camera controls under 6.0.0. Major version 5 was skipped to align LibMultiSense major versions with firmware major versions. 