### PR TITLE
support reproducible builds

### DIFF
--- a/source/LibMultiSense/details/public.cc
+++ b/source/LibMultiSense/details/public.cc
@@ -791,7 +791,6 @@ Status impl::getApiVersion(VersionType& version)
 
 Status impl::getVersionInfo(system::VersionInfo& v)
 {
-    v.apiBuildDate            = std::string(__DATE__ ", " __TIME__);
     v.apiVersion              = API_VERSION;
     v.sensorFirmwareBuildDate = m_sensorVersion.firmwareBuildDate;
     v.sensorFirmwareVersion   = m_sensorVersion.firmwareVersion;

--- a/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
@@ -3138,9 +3138,6 @@ public:
  */
 class MULTISENSE_API VersionInfo {
 public:
-
-    /** The build date of libMultiSense */
-    std::string apiBuildDate;
     /** The version of libMultiSense */
     VersionType apiVersion;
 

--- a/source/Utilities/ChangeFps/ChangeFps.cc
+++ b/source/Utilities/ChangeFps/ChangeFps.cc
@@ -129,7 +129,6 @@ int main(int    argc,
         goto clean_out;
     }
 
-    std::cout << "API build date      :  " << v.apiBuildDate << "\n";
     std::cout << "API version         :  0x" << std::hex << std::setw(4) << std::setfill('0') << v.apiVersion << "\n";
     std::cout << "Firmware build date :  " << v.sensorFirmwareBuildDate << "\n";
     std::cout << "Firmware version    :  0x" << std::hex << std::setw(4) << std::setfill('0') << v.sensorFirmwareVersion << "\n";

--- a/source/Utilities/ChangeResolution/ChangeResolution.cc
+++ b/source/Utilities/ChangeResolution/ChangeResolution.cc
@@ -125,7 +125,6 @@ int main(int    argc,
         goto clean_out;
     }
 
-	std::cout << "API build date      :  " << v.apiBuildDate << "\n";
     std::cout << "API version         :  0x" << std::hex << std::setw(4) << std::setfill('0') << v.apiVersion << "\n";
 	std::cout << "Firmware build date :  " << v.sensorFirmwareBuildDate << "\n";
 	std::cout << "Firmware version    :  0x" << std::hex << std::setw(4) << std::setfill('0') << v.sensorFirmwareVersion << "\n";

--- a/source/Utilities/ChangeTransmitDelay/ChangeTransmitDelay.cc
+++ b/source/Utilities/ChangeTransmitDelay/ChangeTransmitDelay.cc
@@ -122,7 +122,6 @@ int main(int    argc,
         goto clean_out;
     }
 
-	std::cout << "API build date      :  " << v.apiBuildDate << "\n";
         std::cout << "API version         :  0x" << std::hex << std::setw(4) << std::setfill('0') << v.apiVersion << "\n";
 	std::cout << "Firmware build date :  " << v.sensorFirmwareBuildDate << "\n";
 	std::cout << "Firmware version    :  0x" << std::hex << std::setw(4) << std::setfill('0') << v.sensorFirmwareVersion << "\n";

--- a/source/Utilities/ImuConfigUtility/ImuConfigUtility.cc
+++ b/source/Utilities/ImuConfigUtility/ImuConfigUtility.cc
@@ -166,7 +166,6 @@ int main(int    argc,
 
     if (query) {
 		std::cout << "Version information:\n";
-		std::cout << "\tAPI build date      :  " << v.apiBuildDate << "\n";
         std::cout << "\tAPI version         :  0x" << std::hex << std::setw(4) << std::setfill('0') << v.apiVersion << "\n";
 		std::cout << "\tFirmware build date :  " << v.sensorFirmwareBuildDate << "\n";
 		std::cout << "\tFirmware version    :  0x" << std::hex << std::setw(4) << std::setfill('0') << v.sensorFirmwareVersion << "\n";

--- a/source/Utilities/SaveImageUtility/SaveImageUtility.cc
+++ b/source/Utilities/SaveImageUtility/SaveImageUtility.cc
@@ -387,7 +387,6 @@ int main(int    argc,
         goto clean_out;
     }
 
-	std::cout << "API build date      :  " << v.apiBuildDate << "\n";
     std::cout << "API version         :  0x" << std::hex << std::setw(4) << std::setfill('0') << v.apiVersion << "\n";
 	std::cout << "Firmware build date :  " << v.sensorFirmwareBuildDate << "\n";
 	std::cout << "Firmware version    :  0x" << std::hex << std::setw(4) << std::setfill('0') << v.sensorFirmwareVersion << "\n";

--- a/source/Utilities/VersionInfoUtility/VersionInfoUtility.cc
+++ b/source/Utilities/VersionInfoUtility/VersionInfoUtility.cc
@@ -78,7 +78,6 @@ void usage(const char *programNameP)
 void printVersionInfo(const system::VersionInfo& info,
                       FILE*                      fP=stdout)
 {
-    fprintf(fP, "API build date: %s\n", info.apiBuildDate.c_str());
     fprintf(fP, "API version: %#06x\n", info.apiVersion);
     fprintf(fP, "\n");
     fprintf(fP, "Firmware build date: %s\n", info.sensorFirmwareBuildDate.c_str());


### PR DESCRIPTION
In contrast to the firmware build time, there does not seem to be a real merit to knowing the build time of the library, but it breaks reproducible builds and errors in gcc with `-Wall -Werror` due to `-Werror=date-time`.

Currently this breaks building `multisense_ros` for ROS-O with
```
/<<BUILDDIR>>package/sensor_api/source/LibMultiSense/details/public.cc:794:45: error: macro "__DATE__" might prevent reproducible builds [-Werror=date-time]
  794 |     v.apiBuildDate            = std::string(__DATE__ ", " __TIME__);
      |                                             ^~~~~~~~
/<<BUILDDIR>>package/sensor_api/source/LibMultiSense/details/public.cc:794:59: error: macro "__TIME__" might prevent reproducible builds [-Werror=date-time]
  794 |     v.apiBuildDate            = std::string(__DATE__ ", " __TIME__);
      |                                                           ^~~~~~~~
cc1plus: all warnings being treated as errors
make[4]: *** [sensor_api/source/LibMultiSense/CMakeFiles/MultiSense.dir/build.make:93: sensor_api/source/LibMultiSense/CMakeFiles/MultiSense.dir/details/public.cc.o] Error 1
```

There are alternatives, such as defining both variables as empty and disabling the error, but I consider this to be the cleanest way out.