### PR TITLE
Fix memleak in DepthCache

### DIFF
--- a/source/LibMultiSense/include/MultiSense/details/storage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/storage.hh
@@ -201,6 +201,7 @@ namespace details {
                 m_map[key] = data;
             }
             else {
+                delete it->second;
                 it->second = data;
             }
 


### PR DESCRIPTION
This memory leak only occurs when inserting a key that already exists, as the pointer is not freed and lost.

Closes #122 