### PR TITLE
Convert remote head sync pairs into sync groups

### DIFF
--- a/source/LibMultiSense/include/MultiSense/details/wire/RemoteHeadConfigMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/RemoteHeadConfigMessage.hh
@@ -40,13 +40,52 @@
 #define LibMultiSense_RemoteHeadConfigMessage
 
 #include "MultiSense/details/utility/Portability.hh"
-#include "MultiSense/details/wire/Protocol.hh"
-// #include "MultiSense/MultisenseTypes.hh"
+//#include "MultiSense/details/wire/Protocol.hh"
 
 namespace crl {
 namespace multisense {
 namespace details {
 namespace wire {
+
+class RemoteHeadChannel {
+public:
+    static CRL_CONSTEXPR VersionType VERSION = 1;
+
+    ::crl::multisense::RemoteHeadChannel channel;
+
+    //
+    // Serialization routine
+    //
+    template<class Archive>
+    void serialize(Archive&          message,
+                   const VersionType version)
+    {
+        (void) version;
+
+        message & channel;
+    }
+};
+
+class RemoteHeadSyncGroup {
+public:
+    static CRL_CONSTEXPR VersionType VERSION = 1;
+
+    wire::RemoteHeadChannel controller;
+    std::vector<wire::RemoteHeadChannel> responders;
+
+    //
+    // Serialization routine
+    //
+    template<class Archive>
+        void serialize(Archive&          message,
+                       const VersionType version)
+    {
+        (void) version;
+
+        message & controller;
+        message & responders;
+    }
+};
 
 class RemoteHeadConfig {
 public:
@@ -56,17 +95,13 @@ public:
     //
     // Parameters representing the current camera configuration
 
-    RemoteHeadSyncPair syncPair1;
-    RemoteHeadSyncPair syncPair2;
+    std::vector<wire::RemoteHeadSyncGroup> syncGroups;
 
     //
     // Constructors
 
     RemoteHeadConfig(utility::BufferStreamReader&r, VersionType v) {serialize(r,v);};
-    RemoteHeadConfig():
-        syncPair1(Remote_Head_Invalid,Remote_Head_Invalid),
-        syncPair2(Remote_Head_Invalid,Remote_Head_Invalid)
-        {};
+    RemoteHeadConfig() : syncGroups({}) {};
 
     //
     // Serialization routine
@@ -75,14 +110,9 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
-
         (void) version;
 
-        message & syncPair1.controller;
-        message & syncPair1.responder;
-        message & syncPair2.controller;
-        message & syncPair2.responder;
-
+        message & syncGroups;
     }
 };
 

--- a/source/LibMultiSense/include/MultiSense/details/wire/RemoteHeadControlMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/RemoteHeadControlMessage.hh
@@ -43,6 +43,7 @@
 
 #include "MultiSense/details/utility/Portability.hh"
 #include "MultiSense/details/wire/Protocol.hh"
+#include "MultiSense/details/wire/RemoteHeadConfigMessage.hh"
 // #include "MultiSense/MultisenseTypes.hh"
 
 namespace crl {
@@ -58,16 +59,14 @@ public:
     //
     // Parameters representing the current remote head sync configuration
 
-    RemoteHeadSyncPair syncPair1;
-    RemoteHeadSyncPair syncPair2;
+    std::vector<wire::RemoteHeadSyncGroup> syncGroups;
 
     //
     // Constructors
 
     RemoteHeadControl(utility::BufferStreamReader&r, VersionType v) {serialize(r,v);};
     RemoteHeadControl() :
-        syncPair1(Remote_Head_Invalid,Remote_Head_Invalid),
-        syncPair2(Remote_Head_Invalid,Remote_Head_Invalid)
+        syncGroups({})
         {};
 
     //
@@ -80,10 +79,7 @@ public:
 
         (void) version;
 
-        message & syncPair1.controller;
-        message & syncPair1.responder;
-        message & syncPair2.controller;
-        message & syncPair2.responder;
+        message & syncGroups;
 
     }
 };


### PR DESCRIPTION
Convert the remote head "sync pair" concept into a "sync group" to remove the future restriction that it will only every be possible to synchronize two cameras at a time

This change will require a remote head firmware change