### PR TITLE
Add UDP assembler debug

### DIFF
--- a/source/LibMultiSense/CMakeLists.txt
+++ b/source/LibMultiSense/CMakeLists.txt
@@ -11,6 +11,7 @@ include(CheckFunctionExists)
 check_function_exists(vasprintf HAVE_VASPRINTF)
 
 option (MULTISENSE_USE_MONOTONIC_CLOCK "Build LibMultiSense to use CLOCK_MONOTONIC for network time sync. Defaults to OFF." OFF)
+option (MULTISENSE_UDP_ASSEMBLER_DEBUG "Build LibMultiSense to print any failures to assemble a message. Defaults to OFF." OFF)
 option(MULTISENSE_INSTALL_WIRE_PROTOCOL "Install low level wire headers, for integration with external event systems" OFF)
 
 #
@@ -133,6 +134,10 @@ add_library(MultiSense ${MULTISENSE_HEADERS}
 if (MULTISENSE_USE_MONOTONIC_CLOCK)
     target_compile_definitions(MultiSense PRIVATE USE_MONOTONIC_CLOCK=${MULTISENSE_USE_MONOTONIC_CLOCK})
 endif()
+if (MULTISENSE_UDP_ASSEMBLER_DEBUG)
+    target_compile_definitions(MultiSense PRIVATE UDP_ASSEMBLER_DEBUG=${MULTISENSE_UDP_ASSEMBLER_DEBUG})
+endif()
+
 #
 # Versioning...someday lets automate this somehow
 #

--- a/source/LibMultiSense/details/channel.cc
+++ b/source/LibMultiSense/details/channel.cc
@@ -71,6 +71,7 @@ impl::impl(const std::string& address, const RemoteHeadChannel& cameraId, const 
     m_txSeqId(0),
     m_lastRxSeqId(-1),
     m_unWrappedRxSeqId(0),
+    m_lastUnexpectedSequenceId(-1),
     m_udpTrackerCache(UDP_TRACKER_CACHE_DEPTH),
     m_rxLargeBufferPool(),
     m_rxSmallBufferPool(),

--- a/source/LibMultiSense/include/MultiSense/details/channel.hh
+++ b/source/LibMultiSense/include/MultiSense/details/channel.hh
@@ -402,6 +402,11 @@ private:
     int64_t  m_unWrappedRxSeqId;
 
     //
+    // Sequence ID for tracking lost headers to prevent assembler debug spam
+
+    int64_t m_lastUnexpectedSequenceId;
+
+    //
     // A cache to track incoming messages by sequence ID
 
     DepthCache<int64_t, UdpTracker> m_udpTrackerCache;

--- a/source/LibMultiSense/include/MultiSense/details/storage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/storage.hh
@@ -175,6 +175,15 @@ namespace details {
             remove_(key);
         };
 
+        //
+        // Given that an insertion operation will happen, this function returns whether the
+        // depth cache will drop a key, and if so, what the key that will be dropped is.
+        //
+        std::pair<bool, KEY> will_drop() {
+            utility::ScopedLock lock(m_lock);
+            return will_drop_();
+        };
+
     private:
 
         typedef std::deque<KEY> QueueType;
@@ -239,6 +248,17 @@ namespace details {
                 m_queue.pop_back();
             }
         };
+
+        std::pair<bool, KEY> will_drop_() {
+            const bool will_drop = m_map.size() == m_depth;
+            KEY drop_key; // If will_drop is false, this value is intentionally uninitialized
+
+            if (will_drop)
+            {
+                drop_key = m_queue.back();
+            }
+            return std::pair<bool, KEY>(will_drop, drop_key);
+        }
 
         const std::size_t m_depth;
         MapType           m_map;


### PR DESCRIPTION
If running on a system where network strain is of possible concern, this should print some debug to at least let the user know that there was a failure at the UDP assembly layer.