### PR TITLE
Better handle the status message responses from LibMultiSense

### DIFF
--- a/source/LibMultiSense/details/channel.cc
+++ b/source/LibMultiSense/details/channel.cc
@@ -707,7 +707,7 @@ void *impl::statusThread(void *userDataP)
                 //
                 // If it took less than 5ms each direction for transmission consider this for a valid time offset
 
-                if (latency.getNanoSeconds() < 5000000) {
+                if (latency.getNanoSeconds() < 5'000'000) {
 
                     //
                     // Compute and apply the estimated time offset

--- a/source/LibMultiSense/details/channel.cc
+++ b/source/LibMultiSense/details/channel.cc
@@ -685,7 +685,7 @@ void *impl::statusThread(void *userDataP)
             // Wait for the response
 
             Status status;
-            if (ack.wait(status, 0.010)) {
+            if (ack.wait(status, DEFAULT_ACK_TIMEOUT())) {
 
                 //
                 // Record (approx) time of response
@@ -705,11 +705,17 @@ void *impl::statusThread(void *userDataP)
                 const utility::TimeStamp latency((pong.getNanoSeconds() - ping.getNanoSeconds()) / 2);
 
                 //
-                // Compute and apply the estimated time offset
+                // If it took less than 5ms each direction for transmission consider this for a valid time offset
 
-                const utility::TimeStamp offset = ping + latency - msg.uptime;
+                if (latency.getNanoSeconds() < 5000000) {
 
-                selfP->applySensorTimeOffset(offset);
+                    //
+                    // Compute and apply the estimated time offset
+
+                    const utility::TimeStamp offset = ping + latency - msg.uptime;
+
+                    selfP->applySensorTimeOffset(offset);
+                }
 
                 //
                 // Cache the status message


### PR DESCRIPTION
A timeout of 0.01s for a status message response is too short. Increase the time, and use a subset of the responses to update the estimate between the camera's time and the system time. 