### PR TITLE
Fix network timesync underflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,11 @@ endif()
 
 option (MULTISENSE_BUILD_UTILITIES "Build MultiSense utility applications. Defaults to ON for backwards compatibility." ON)
 option (BUILD_SHARED_LIBS "Build LibMultiSense as a shared library. Defaults to ON." ON)
+option (BUILD_TESTS "Build LibMultiSense GTests. Defaults to OFF." OFF)
+
+if (BUILD_TESTS)
+    enable_testing()
+endif()
 
 #
 # We want to build "Release" by default
@@ -82,19 +87,6 @@ set (CMAKE_SKIP_BUILD_RPATH FALSE)
 set (CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 set (CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
 set (CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
-#
-# Write target outputs to bin and lib directories
-#
-if (NOT CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
-    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-endif ()
-if (NOT CMAKE_LIBRARY_OUTPUT_DIRECTORY)
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-endif ()
-if (NOT CMAKE_RUNTIME_OUTPUT_DIRECTORY)
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-endif ()
 
 #
 # Dispatch to subordinate CMakeList.txt files.

--- a/source/LibMultiSense/CMakeLists.txt
+++ b/source/LibMultiSense/CMakeLists.txt
@@ -10,8 +10,8 @@ include(CheckFunctionExists)
 
 check_function_exists(vasprintf HAVE_VASPRINTF)
 
-option (MULTISENSE_USE_MONOTONIC_CLOCK "Build LibMultiSense to use CLOCK_MONOTONIC for network time sync. Defaults to OFF." OFF)
-option (MULTISENSE_UDP_ASSEMBLER_DEBUG "Build LibMultiSense to print any failures to assemble a message. Defaults to OFF." OFF)
+option(MULTISENSE_USE_MONOTONIC_CLOCK "Build LibMultiSense to use CLOCK_MONOTONIC for network time sync. Defaults to OFF." OFF)
+option(MULTISENSE_UDP_ASSEMBLER_DEBUG "Build LibMultiSense to print any failures to assemble a message. Defaults to OFF." OFF)
 option(MULTISENSE_INSTALL_WIRE_PROTOCOL "Install low level wire headers, for integration with external event systems" OFF)
 
 #
@@ -164,6 +164,10 @@ include(CMakePackageConfigHelpers)
 configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/MultiSenseConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/MultiSenseConfig.cmake
   INSTALL_DESTINATION lib/cmake/MultiSense)
+
+if (BUILD_TESTS)
+    add_subdirectory(test)
+endif()
 
 # create install targets
 install(TARGETS MultiSense

--- a/source/LibMultiSense/details/channel.cc
+++ b/source/LibMultiSense/details/channel.cc
@@ -628,10 +628,7 @@ void impl::applySensorTimeOffset(const utility::TimeStamp& offset)
 
     const double newOffset = utility::decayedAverage(currentOffset, samples, measuredOffset);
 
-    const int32_t newOffsetSeconds = static_cast<int32_t>(newOffset);
-    const int32_t newOffsetMicroSeconds = static_cast<int32_t>((newOffset - newOffsetSeconds) * 1e6);
-
-    m_timeOffset = utility::TimeStamp(newOffsetSeconds, newOffsetMicroSeconds);
+    m_timeOffset = utility::TimeStamp(static_cast<int64_t>(newOffset * 1e9));
 }
 
 //

--- a/source/LibMultiSense/include/MultiSense/details/utility/TimeStamp.hh
+++ b/source/LibMultiSense/include/MultiSense/details/utility/TimeStamp.hh
@@ -94,6 +94,7 @@ public:
     TimeStamp(int32_t seconds, int32_t microSeconds);
     TimeStamp(int64_t nanoseconds);
     TimeStamp(const struct timeval& value);
+
     //
     // For setting the timestamp.
     //
@@ -102,14 +103,21 @@ public:
     void set(int32_t seconds, int32_t microSeconds);
 
     //
+    // Get the seconds portion of the underlying timeval
     // For getting precise values from the timestamp.
     //
 
     int32_t getSeconds() const;
+
+    //
+    // Get the microseconds portion of the underlying timeval
+    // For getting precise values from the timestamp.
+    //
+
     int32_t getMicroSeconds() const;
 
     //
-    // Get the time in nanoseconds
+    // Get the time in nanoseconds, aggregates seconds and microseconds
     //
 
     int64_t getNanoSeconds() const;
@@ -122,6 +130,7 @@ public:
     TimeStamp operator-(TimeStamp const& other) const;
     TimeStamp& operator+=(TimeStamp const& other);
     TimeStamp& operator-=(TimeStamp const& other);
+
 };
 
 }}}} // namespaces

--- a/source/LibMultiSense/test/CMakeLists.txt
+++ b/source/LibMultiSense/test/CMakeLists.txt
@@ -1,15 +1,12 @@
-find_package(GTest)
+find_package(GTest REQUIRED)
 
-if (GTEST_FOUND)
+set(TEST_NAMES
+    TestTimestamp)
 
-    set(TEST_NAMES
-        TestTimestamp)
+foreach(TEST_NAME ${TEST_NAMES})
+    add_executable(${TEST_NAME} ${TEST_NAME}.cc)
+    target_link_libraries(${TEST_NAME} PRIVATE MultiSense
+                                               GTest::GTest GTest::Main)
 
-    foreach(TEST_NAME ${TEST_NAMES})
-        add_executable(${TEST_NAME} ${TEST_NAME}.cc)
-        target_link_libraries(${TEST_NAME} PRIVATE MultiSense
-                                                   GTest::GTest GTest::Main)
-
-        add_test(${TEST_NAME} ${TEST_NAME})
-    endforeach()
-endif()
+    add_test(${TEST_NAME} ${TEST_NAME})
+endforeach()

--- a/source/LibMultiSense/test/CMakeLists.txt
+++ b/source/LibMultiSense/test/CMakeLists.txt
@@ -1,0 +1,15 @@
+find_package(GTest)
+
+if (GTEST_FOUND)
+
+    set(TEST_NAMES
+        TestTimestamp)
+
+    foreach(TEST_NAME ${TEST_NAMES})
+        add_executable(${TEST_NAME} ${TEST_NAME}.cc)
+        target_link_libraries(${TEST_NAME} PRIVATE MultiSense
+                                                   GTest::GTest GTest::Main)
+
+        add_test(${TEST_NAME} ${TEST_NAME})
+    endforeach()
+endif()

--- a/source/LibMultiSense/test/TestTimestamp.cc
+++ b/source/LibMultiSense/test/TestTimestamp.cc
@@ -1,0 +1,135 @@
+/**
+ * @file LibMultiSense/test/TestTimestamp.hh
+ *
+ * Copyright 2023
+ * Carnegie Robotics, LLC
+ * 4501 Hatfield Street, Pittsburgh, PA 15201
+ * http://www.carnegierobotics.com
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Carnegie Robotics, LLC nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL CARNEGIE ROBOTICS, LLC BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Significant history (date, user, job code, action):
+ *   2023-12-12, malvarado@carnegierobotics.com, IRAD, Created file.
+ **/
+
+#ifndef CRL_MULTISENSE_TIMESTAMP_TEST_HH
+#define CRL_MULTISENSE_TIMESTAMP_TEST_HH
+
+#include "MultiSense/details/utility/TimeStamp.hh"
+
+#include <gtest/gtest.h>
+
+using namespace crl::multisense::details::utility;
+
+TEST(TimeStamp, nanosecond_construction)
+{
+    const TimeStamp a(1000);
+
+    EXPECT_EQ(a.getNanoSeconds(), 1000);
+    EXPECT_EQ(a.getSeconds(), 0);
+    EXPECT_EQ(a.getMicroSeconds(), 1);
+
+    const TimeStamp b(-1000);
+
+    EXPECT_EQ(b.getNanoSeconds(), -1000);
+    EXPECT_EQ(b.getSeconds(), 0);
+    EXPECT_EQ(b.getMicroSeconds(), -1);
+
+    const TimeStamp c(-1000001000);
+
+    EXPECT_EQ(c.getNanoSeconds(), -1000001000);
+    EXPECT_EQ(c.getSeconds(), -1);
+    EXPECT_EQ(c.getMicroSeconds(), 1);
+}
+
+TEST(TimeStamp, addition)
+{
+    const TimeStamp a(123, 456);
+    const TimeStamp b(567, 789);
+
+    const TimeStamp sum = a + b;
+
+    EXPECT_EQ(sum.getSeconds(), 123 + 567);
+    EXPECT_EQ(sum.getMicroSeconds(), 456 + 789);
+}
+
+TEST(TimeStamp, addition_negative_time)
+{
+    const TimeStamp a(-10000001000);
+    const TimeStamp b(-20000002000);
+
+    const TimeStamp sum = a + b;
+
+    EXPECT_EQ(sum.getNanoSeconds(), -30000003000);
+    EXPECT_EQ(sum.getSeconds(), -30);
+    EXPECT_EQ(sum.getMicroSeconds(), 3);
+}
+
+TEST(TimeStamp, addition_rollover)
+{
+    const TimeStamp a(123, 999999);
+    const TimeStamp b(567, 2);
+
+    const TimeStamp sum = a + b;
+
+    EXPECT_EQ(sum.getSeconds(), 123 + 567 + 1);
+    EXPECT_EQ(sum.getMicroSeconds(), 1);
+}
+
+TEST(TimeStamp, subtraction)
+{
+    const TimeStamp a(123, 1);
+    const TimeStamp b(567, 2000);
+
+    const TimeStamp sum = b - a;
+
+    EXPECT_EQ(sum.getSeconds(), 567 - 123);
+    EXPECT_EQ(sum.getMicroSeconds(), 2000 - 1);
+}
+
+TEST(TimeStamp, subtraction_negative_time)
+{
+    const TimeStamp a(-10000001000);
+    const TimeStamp b(-20000002000);
+
+    const TimeStamp sum = a - b;
+
+    EXPECT_EQ(sum.getNanoSeconds(), 10000001000);
+    EXPECT_EQ(sum.getSeconds(), 10);
+    EXPECT_EQ(sum.getMicroSeconds(), 1);
+}
+
+TEST(TimeStamp, subtraction_rollover)
+{
+    const TimeStamp a(123, 2000);
+    const TimeStamp b(567, 1);
+
+    const TimeStamp sum = a - b;
+
+    EXPECT_EQ(sum.getSeconds(), 123 - 567 + 1);
+    EXPECT_EQ(sum.getMicroSeconds(), 1000000 - 2000 + 1);
+}
+
+#endif /* #ifndef CRL_MULTISENSE_TIMESTAMP_TEST_HH */


### PR DESCRIPTION
In cases where the cameras timestamp is greater than the system timestamp the computed time offset between the host and camera will be negative. This breaks the assumptions of the TimeStamp class, and can lead to a underflow of the microseconds field. Refactor the Timestamp class to properly support positive and negative nanoseconds, and perform addition and subtraction operations using nanoseconds. 