### PR TITLE
Replace initializations which are only supported in c++11

### DIFF
--- a/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
@@ -37,11 +37,12 @@
 #ifndef LibMultiSense_MultiSenseTypes_hh
 #define LibMultiSense_MultiSenseTypes_hh
 
-#include <stdint.h>
 #include <climits>
+#include <cstring>
+#include <iostream>
+#include <stdint.h>
 #include <string>
 #include <vector>
-#include <iostream>
 
 #if defined (CRL_HAVE_CONSTEXPR)
 #define CRL_CONSTEXPR constexpr
@@ -4078,7 +4079,7 @@ class MULTISENSE_API PtpStatus {
         uint8_t gm_present;
 
         /** Hex ID of grandmaster clock. */
-        uint8_t gm_id[8] = {0};
+        uint8_t gm_id[8];
 
         /** Offset of camera PHC to PTP grandmaster clock in nanosec */
         int64_t gm_offset;
@@ -4094,7 +4095,10 @@ class MULTISENSE_API PtpStatus {
             gm_present(0),
             gm_offset(0),
             path_delay(0),
-            steps_removed(0) {};
+            steps_removed(0)
+        {
+            memset(gm_id, 0, sizeof(gm_id));
+        };
 };
 
 /**

--- a/source/LibMultiSense/include/MultiSense/details/wire/PtpStatusResponseMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/PtpStatusResponseMessage.hh
@@ -41,6 +41,7 @@
 
 #include "MultiSense/details/utility/Portability.hh"
 #include <iostream>
+#include <cstring>
 
 namespace crl {
 namespace multisense {
@@ -54,7 +55,7 @@ public:
 
     //
     // Camera PTP status parameters
-    
+    //
     uint8_t gm_present;
     int64_t gm_offset;
 
@@ -70,17 +71,20 @@ public:
 
     //
     // GM Clock identity (8 bytes, 0xXXXXXX.XXXX.XXXXXX)
-    
-    uint8_t gm_id[8] = {0};
+    //
+    uint8_t gm_id[8];
 
     //
     // Constructors
 
     PtpStatusResponse(utility::BufferStreamReader&r, VersionType v) {serialize(r,v);};
-    PtpStatusResponse() : gm_present(0), 
-                          gm_offset(0),  
-                          path_delay(0), 
-                          steps_removed(0) {};
+    PtpStatusResponse() : gm_present(0),
+                          gm_offset(0),
+                          path_delay(0),
+                          steps_removed(0)
+    {
+        memset(gm_id, 0, sizeof(gm_id));
+    };
 
     //
     // Serialization routine

--- a/source/Utilities/FeatureDetectorUtility/CMakeLists.txt
+++ b/source/Utilities/FeatureDetectorUtility/CMakeLists.txt
@@ -3,19 +3,32 @@
 #
 
 #
-# Setup the executable that we will use.
+# This utility requires c++14
 #
 
-add_executable(FeatureDetectorUtility FeatureDetectorUtility.cc)
+if ((CMAKE_CXX_COMPILER_ID MATCHES MSVC AND
+    CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 14.0) OR
+    (CMAKE_CXX_COMPILER_ID MATCHES GNU AND
+    CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9) OR
+    (CMAKE_CXX_COMPILER_ID MATCHES Clang AND
+    CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 3.4))
 
-#
-# Specify libraries against which to link.
-#
+    set(CMAKE_CXX_STANDARD 14)
+    #
+    # Setup the executable that we will use.
+    #
 
-target_link_libraries (FeatureDetectorUtility ${MULTISENSE_UTILITY_LIBS})
+    add_executable(FeatureDetectorUtility FeatureDetectorUtility.cc)
 
-#
-# Specify the install location
-#
+    #
+    # Specify libraries against which to link.
+    #
 
-install(TARGETS FeatureDetectorUtility RUNTIME DESTINATION "bin")
+    target_link_libraries (FeatureDetectorUtility ${MULTISENSE_UTILITY_LIBS})
+
+    #
+    # Specify the install location
+    #
+
+    install(TARGETS FeatureDetectorUtility RUNTIME DESTINATION "bin")
+endif()


### PR DESCRIPTION
Allow LibMultiSense to build with compilers which do not default support c++11 or newer