### PR TITLE
Psmithcrl/aux feature support

### DIFF
--- a/source/LibMultiSense/details/channel.cc
+++ b/source/LibMultiSense/details/channel.cc
@@ -471,6 +471,7 @@ wire::SourceType impl::sourceApiToWire(DataSource mask)
     if (mask & Source_Rgb_Left)               wire_mask |= wire::SOURCE_RGB_LEFT;
     if (mask & Source_Feature_Left)           wire_mask |= wire::SOURCE_FEATURE_LEFT;
     if (mask & Source_Feature_Right)          wire_mask |= wire::SOURCE_FEATURE_RIGHT;
+    if (mask & Source_Feature_Aux)            wire_mask |= wire::SOURCE_FEATURE_AUX;
     if (mask & Source_Lidar_Scan)             wire_mask |= wire::SOURCE_LIDAR_SCAN;
     if (mask & Source_Imu)                    wire_mask |= wire::SOURCE_IMU;
     if (mask & Source_Pps)                    wire_mask |= wire::SOURCE_PPS;
@@ -512,6 +513,7 @@ DataSource impl::sourceWireToApi(wire::SourceType mask)
     if (mask & wire::SOURCE_RGB_LEFT)          api_mask |= Source_Rgb_Left;
     if (mask & wire::SOURCE_FEATURE_LEFT)      api_mask |= Source_Feature_Left;
     if (mask & wire::SOURCE_FEATURE_RIGHT)     api_mask |= Source_Feature_Left;
+    if (mask & wire::SOURCE_FEATURE_AUX)       api_mask |= Source_Feature_Aux;
     if (mask & wire::SOURCE_LIDAR_SCAN)        api_mask |= Source_Lidar_Scan;
     if (mask & wire::SOURCE_IMU)               api_mask |= Source_Imu;
     if (mask & wire::SOURCE_PPS)               api_mask |= Source_Pps;

--- a/source/LibMultiSense/details/channel.cc
+++ b/source/LibMultiSense/details/channel.cc
@@ -512,7 +512,7 @@ DataSource impl::sourceWireToApi(wire::SourceType mask)
     if (mask & wire::SOURCE_JPEG_LEFT)         api_mask |= Source_Jpeg_Left;
     if (mask & wire::SOURCE_RGB_LEFT)          api_mask |= Source_Rgb_Left;
     if (mask & wire::SOURCE_FEATURE_LEFT)      api_mask |= Source_Feature_Left;
-    if (mask & wire::SOURCE_FEATURE_RIGHT)     api_mask |= Source_Feature_Left;
+    if (mask & wire::SOURCE_FEATURE_RIGHT)     api_mask |= Source_Feature_Right;
     if (mask & wire::SOURCE_FEATURE_AUX)       api_mask |= Source_Feature_Aux;
     if (mask & wire::SOURCE_LIDAR_SCAN)        api_mask |= Source_Lidar_Scan;
     if (mask & wire::SOURCE_IMU)               api_mask |= Source_Imu;

--- a/source/LibMultiSense/details/dispatch.cc
+++ b/source/LibMultiSense/details/dispatch.cc
@@ -354,7 +354,7 @@ void impl::dispatch(utility::BufferStreamWriter& buffer)
 
         getImageTime(metaP, header.timeSeconds, header.timeMicroSeconds);
 
-        header.source           = sourceWireToApi(image.source);
+        header.source           = image.source | ((uint64_t)image.sourceExtended << 32);
         header.bitsPerPixel     = 0;
         header.width            = image.width;
         header.height           = image.height;
@@ -382,7 +382,7 @@ void impl::dispatch(utility::BufferStreamWriter& buffer)
 
         getImageTime(metaP, header.timeSeconds, header.timeMicroSeconds);
 
-        header.source           = sourceWireToApi(image.source);
+        header.source           = image.source | ((uint64_t)image.sourceExtended << 32);
         header.bitsPerPixel     = image.bitsPerPixel;
         header.width            = image.width;
         header.height           = image.height;
@@ -500,7 +500,7 @@ void impl::dispatch(utility::BufferStreamWriter& buffer)
 
         getImageTime(metaP, header.timeSeconds, header.timeMicroSeconds);
 
-        header.source           = sourceWireToApi(image.source);
+        header.source           = image.source | ((uint64_t)image.sourceExtended << 32);
         header.bitsPerPixel     = image.bitsPerPixel;
         header.codec            = image.codec;
         header.width            = image.width;
@@ -605,20 +605,20 @@ void impl::dispatch(utility::BufferStreamWriter& buffer)
           break;
 
         feature_detector::Header header;
-        header.source         =featureDetector.source | ((uint64_t)featureDetector.sourceExtended << 32);
-        header.frameId        =metaP->frameId;
-        header.timeSeconds    =metaP->timeSeconds;
-        header.timeNanoSeconds=metaP->timeNanoSeconds;
-        header.ptpNanoSeconds =metaP->ptpNanoSeconds;
-        header.octaveWidth    =metaP->octaveWidth;
-        header.octaveHeight   =metaP->octaveHeight;
-        header.numOctaves     =metaP->numOctaves;
-        header.scaleFactor    =metaP->scaleFactor;
-        header.motionStatus   =metaP->motionStatus;
-        header.averageXMotion =metaP->averageXMotion;
-        header.averageYMotion =metaP->averageYMotion;
-        header.numFeatures    =featureDetector.numFeatures;
-        header.numDescriptors =featureDetector.numDescriptors;
+        header.source         = featureDetector.source | ((uint64_t)featureDetector.sourceExtended << 32);
+        header.frameId        = metaP->frameId;
+        header.timeSeconds    = metaP->timeSeconds;
+        header.timeNanoSeconds= metaP->timeNanoSeconds;
+        header.ptpNanoSeconds = metaP->ptpNanoSeconds;
+        header.octaveWidth    = metaP->octaveWidth;
+        header.octaveHeight   = metaP->octaveHeight;
+        header.numOctaves     = metaP->numOctaves;
+        header.scaleFactor    = metaP->scaleFactor;
+        header.motionStatus   = metaP->motionStatus;
+        header.averageXMotion = metaP->averageXMotion;
+        header.averageYMotion = metaP->averageYMotion;
+        header.numFeatures    = featureDetector.numFeatures;
+        header.numDescriptors = featureDetector.numDescriptors;
 
         const size_t startDescriptor=featureDetector.numFeatures*sizeof(wire::Feature);
 

--- a/source/LibMultiSense/details/dispatch.cc
+++ b/source/LibMultiSense/details/dispatch.cc
@@ -605,7 +605,7 @@ void impl::dispatch(utility::BufferStreamWriter& buffer)
           break;
 
         feature_detector::Header header;
-        header.source         =featureDetector.source;
+        header.source         =featureDetector.source | ((uint64_t)featureDetector.sourceExtended << 32);
         header.frameId        =metaP->frameId;
         header.timeSeconds    =metaP->timeSeconds;
         header.timeNanoSeconds=metaP->timeNanoSeconds;

--- a/source/LibMultiSense/details/public.cc
+++ b/source/LibMultiSense/details/public.cc
@@ -1283,10 +1283,10 @@ Status impl::getDeviceModes(std::vector<system::DeviceMode>& modes)
 
         system::DeviceMode&     a = modes[i];
         const wire::DeviceMode& w = d.modes[i];
-
+        const wire::SourceType  s = ((uint64_t)w.extendedDataSources) << 32 | w.supportedDataSources;
         a.width                = w.width;
         a.height               = w.height;
-        a.supportedDataSources = sourceWireToApi(w.supportedDataSources);
+        a.supportedDataSources = sourceWireToApi(s);
         if (m_sensorVersion.firmwareVersion >= 0x0203)
             a.disparities = w.disparities;
         else

--- a/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
@@ -114,7 +114,7 @@ static CRL_CONSTEXPR Status Status_Exception   = -6;
 typedef uint64_t DataSource;
 
 static CRL_CONSTEXPR DataSource Source_Unknown                       = 0;
-static CRL_CONSTEXPR DataSource Source_All                           = 0xffffffff;
+static CRL_CONSTEXPR DataSource Source_All                           = 0xffffffffffffffff;
 static CRL_CONSTEXPR DataSource Source_Raw_Left                      = (1ull<<0);
 static CRL_CONSTEXPR DataSource Source_Raw_Right                     = (1ull<<1);
 static CRL_CONSTEXPR DataSource Source_Luma_Left                     = (1ull<<2);

--- a/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
@@ -3000,7 +3000,7 @@ namespace feature_detector {
   class MULTISENSE_API Header : public HeaderBase {
   public:
 
-      uint32_t source;
+      DataSource source;
       int64_t  frameId;
       uint32_t timeSeconds;
       uint32_t timeNanoSeconds;

--- a/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
@@ -111,44 +111,45 @@ static CRL_CONSTEXPR Status Status_Exception   = -6;
  * sensor. DataSource values can be combined using the bitwise OR
  * operator to represent multiple sources.
  */
-typedef uint32_t DataSource;
+typedef uint64_t DataSource;
 
 static CRL_CONSTEXPR DataSource Source_Unknown                       = 0;
 static CRL_CONSTEXPR DataSource Source_All                           = 0xffffffff;
-static CRL_CONSTEXPR DataSource Source_Raw_Left                      = (1U<<0);
-static CRL_CONSTEXPR DataSource Source_Raw_Right                     = (1U<<1);
-static CRL_CONSTEXPR DataSource Source_Luma_Left                     = (1U<<2);
-static CRL_CONSTEXPR DataSource Source_Luma_Right                    = (1U<<3);
-static CRL_CONSTEXPR DataSource Source_Luma_Rectified_Left           = (1U<<4);
-static CRL_CONSTEXPR DataSource Source_Luma_Rectified_Right          = (1U<<5);
-static CRL_CONSTEXPR DataSource Source_Chroma_Left                   = (1U<<6);
-static CRL_CONSTEXPR DataSource Source_Chroma_Right                  = (1U<<7);
-static CRL_CONSTEXPR DataSource Source_Chroma_Rectified_Aux          = (1U<<8);
-static CRL_CONSTEXPR DataSource Source_Disparity                     = (1U<<10);
-static CRL_CONSTEXPR DataSource Source_Disparity_Left                = (1U<<10); // same as Source_Disparity
-static CRL_CONSTEXPR DataSource Source_Disparity_Right               = (1U<<11);
-static CRL_CONSTEXPR DataSource Source_Disparity_Cost                = (1U<<12);
-static CRL_CONSTEXPR DataSource Source_Jpeg_Left                     = (1U<<16);
-static CRL_CONSTEXPR DataSource Source_Rgb_Left                      = (1U<<17);
-static CRL_CONSTEXPR DataSource Source_Feature_Left                  = (1U<<18);
-static CRL_CONSTEXPR DataSource Source_Feature_Right                 = (1U<<19);
-static CRL_CONSTEXPR DataSource Source_Ground_Surface_Spline_Data    = (1U<<20);
-static CRL_CONSTEXPR DataSource Source_Ground_Surface_Class_Image    = (1U<<22);
-static CRL_CONSTEXPR DataSource Source_AprilTag_Detections           = (1U<<23);
-static CRL_CONSTEXPR DataSource Source_Lidar_Scan                    = (1U<<24);
-static CRL_CONSTEXPR DataSource Source_Imu                           = (1U<<25);
-static CRL_CONSTEXPR DataSource Source_Pps                           = (1U<<26);
-static CRL_CONSTEXPR DataSource Source_Raw_Aux                       = (1U<<27);
-static CRL_CONSTEXPR DataSource Source_Luma_Aux                      = (1U<<28);
-static CRL_CONSTEXPR DataSource Source_Luma_Rectified_Aux            = (1U<<29);
-static CRL_CONSTEXPR DataSource Source_Chroma_Aux                    = (1U<<30);
-static CRL_CONSTEXPR DataSource Source_Disparity_Aux                 = (1U<<31);
-static CRL_CONSTEXPR DataSource Source_Compressed_Left               = (1U<<9);
-static CRL_CONSTEXPR DataSource Source_Compressed_Right              = (1U<<13);
-static CRL_CONSTEXPR DataSource Source_Compressed_Aux                = (1U<<14);
-static CRL_CONSTEXPR DataSource Source_Compressed_Rectified_Left     = (1U<<15);
-static CRL_CONSTEXPR DataSource Source_Compressed_Rectified_Right    = (1U<<16);
-static CRL_CONSTEXPR DataSource Source_Compressed_Rectified_Aux      = (1U<<17);
+static CRL_CONSTEXPR DataSource Source_Raw_Left                      = (1ull<<0);
+static CRL_CONSTEXPR DataSource Source_Raw_Right                     = (1ull<<1);
+static CRL_CONSTEXPR DataSource Source_Luma_Left                     = (1ull<<2);
+static CRL_CONSTEXPR DataSource Source_Luma_Right                    = (1ull<<3);
+static CRL_CONSTEXPR DataSource Source_Luma_Rectified_Left           = (1ull<<4);
+static CRL_CONSTEXPR DataSource Source_Luma_Rectified_Right          = (1ull<<5);
+static CRL_CONSTEXPR DataSource Source_Chroma_Left                   = (1ull<<6);
+static CRL_CONSTEXPR DataSource Source_Chroma_Right                  = (1ull<<7);
+static CRL_CONSTEXPR DataSource Source_Chroma_Rectified_Aux          = (1ull<<8);
+static CRL_CONSTEXPR DataSource Source_Disparity                     = (1ull<<10);
+static CRL_CONSTEXPR DataSource Source_Disparity_Left                = (1ull<<10); // same as Source_Disparity
+static CRL_CONSTEXPR DataSource Source_Disparity_Right               = (1ull<<11);
+static CRL_CONSTEXPR DataSource Source_Disparity_Cost                = (1ull<<12);
+static CRL_CONSTEXPR DataSource Source_Jpeg_Left                     = (1ull<<16);
+static CRL_CONSTEXPR DataSource Source_Rgb_Left                      = (1ull<<17);
+static CRL_CONSTEXPR DataSource Source_Feature_Left                  = (1ull<<18);
+static CRL_CONSTEXPR DataSource Source_Feature_Right                 = (1ull<<19);
+static CRL_CONSTEXPR DataSource Source_Feature_Aux                   = (1ull<<32);
+static CRL_CONSTEXPR DataSource Source_Ground_Surface_Spline_Data    = (1ull<<20);
+static CRL_CONSTEXPR DataSource Source_Ground_Surface_Class_Image    = (1ull<<22);
+static CRL_CONSTEXPR DataSource Source_AprilTag_Detections           = (1ull<<23);
+static CRL_CONSTEXPR DataSource Source_Lidar_Scan                    = (1ull<<24);
+static CRL_CONSTEXPR DataSource Source_Imu                           = (1ull<<25);
+static CRL_CONSTEXPR DataSource Source_Pps                           = (1ull<<26);
+static CRL_CONSTEXPR DataSource Source_Raw_Aux                       = (1ull<<27);
+static CRL_CONSTEXPR DataSource Source_Luma_Aux                      = (1ull<<28);
+static CRL_CONSTEXPR DataSource Source_Luma_Rectified_Aux            = (1ull<<29);
+static CRL_CONSTEXPR DataSource Source_Chroma_Aux                    = (1ull<<30);
+static CRL_CONSTEXPR DataSource Source_Disparity_Aux                 = (1ull<<31);
+static CRL_CONSTEXPR DataSource Source_Compressed_Left               = (1ull<<9);
+static CRL_CONSTEXPR DataSource Source_Compressed_Right              = (1ull<<13);
+static CRL_CONSTEXPR DataSource Source_Compressed_Aux                = (1ull<<14);
+static CRL_CONSTEXPR DataSource Source_Compressed_Rectified_Left     = (1ull<<15);
+static CRL_CONSTEXPR DataSource Source_Compressed_Rectified_Right    = (1ull<<16);
+static CRL_CONSTEXPR DataSource Source_Compressed_Rectified_Aux      = (1ull<<17);
 
 /**
  * Use Roi_Full_Image as the height and width when setting the autoExposureRoi

--- a/source/LibMultiSense/include/MultiSense/details/wire/CamConfigMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/CamConfigMessage.hh
@@ -110,7 +110,7 @@ public:
     //
     // Version 7 additions
 
-    SourceType exposureSource;
+    uint32_t exposureSource;
     std::vector<ExposureConfig> secondaryExposureConfigs;
 
     //

--- a/source/LibMultiSense/include/MultiSense/details/wire/CamControlMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/CamControlMessage.hh
@@ -103,7 +103,7 @@ public:
     //
     // Additions in version 7
 
-    SourceType exposureSource; // Deprecated
+    uint32_t exposureSource; // Deprecated
     std::vector<ExposureConfig> secondaryExposureConfigs; // Deprecated
 
     //

--- a/source/LibMultiSense/include/MultiSense/details/wire/CompressedImageMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/CompressedImageMessage.hh
@@ -51,7 +51,7 @@ class WIRE_HEADER_ATTRIBS_ CompressedImageHeader {
 public:
 
 static CRL_CONSTEXPR IdType      ID      = ID_DATA_COMPRESSED_IMAGE;
-static CRL_CONSTEXPR VersionType VERSION = 0;
+static CRL_CONSTEXPR VersionType VERSION = 1;
 
 #ifdef SENSORPOD_FIRMWARE
     IdType      id;
@@ -67,6 +67,7 @@ static CRL_CONSTEXPR VersionType VERSION = 0;
     uint32_t exposure;
     float gain;
     uint32_t compressedDataBufferSize;
+    uint32_t sourceExtended;
 
     CompressedImageHeader()
         :
@@ -82,7 +83,8 @@ static CRL_CONSTEXPR VersionType VERSION = 0;
         height(0),
         exposure(0),
         gain(0.0),
-        compressedDataBufferSize(0)
+        compressedDataBufferSize(0),
+        sourceExtended(0)
         {};
 };
 
@@ -106,7 +108,6 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
-        (void) version;
         message & source;
         message & bitsPerPixel;
         message & codec;
@@ -125,6 +126,15 @@ public:
 
             dataP = message.peek();
             message.seek(message.tell() + compressedDataBufferSize);
+        }
+
+        if (version >= 1)
+        {
+          message & sourceExtended;
+        }
+        else
+        {
+          sourceExtended = 0;
         }
 
     }

--- a/source/LibMultiSense/include/MultiSense/details/wire/ExposureConfigMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/ExposureConfigMessage.hh
@@ -62,7 +62,7 @@ public:
     uint16_t autoExposureRoiWidth;
     uint16_t autoExposureRoiHeight;
 
-    SourceType exposureSource;
+    uint32_t exposureSource;
     float      autoExposureTargetIntensity;
     float      gain;
 

--- a/source/LibMultiSense/include/MultiSense/details/wire/FeatureDetectorMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/FeatureDetectorMessage.hh
@@ -151,10 +151,6 @@ public:
         message & frameId;
         message & numFeatures;
         message & numDescriptors;
-        if (version >= 2)
-        {
-            message & sourceExtended;
-        }
 
         const uint32_t featureDataSize = static_cast<uint32_t> (std::ceil( numFeatures*sizeof(wire::Feature) + numDescriptors*sizeof(wire::Descriptor)));
 
@@ -166,6 +162,15 @@ public:
 
             dataP = message.peek();
             message.seek(message.tell() + featureDataSize);
+        }
+
+        if (version >= 2)
+        {
+          message & sourceExtended;
+        }
+        else
+        {
+          sourceExtended = 0;
         }
     }
 

--- a/source/LibMultiSense/include/MultiSense/details/wire/FeatureDetectorMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/FeatureDetectorMessage.hh
@@ -96,7 +96,7 @@ public:
 class WIRE_HEADER_ATTRIBS_ FeatureDetectorHeader {
 public:
     static CRL_CONSTEXPR IdType      ID         = ID_DATA_FEATURE_DETECTOR;
-    static CRL_CONSTEXPR VersionType VERSION    = 1;
+    static CRL_CONSTEXPR VersionType VERSION    = 2;
 
 #ifdef SENSORPOD_FIRMWARE
     IdType                 id;
@@ -106,6 +106,7 @@ public:
     int64_t                frameId;
     uint16_t               numFeatures;
     uint16_t               numDescriptors;
+    uint32_t               sourceExtended;
 
 
     FeatureDetectorHeader() :
@@ -116,7 +117,8 @@ public:
         source(0),
         frameId(0),
         numFeatures(0),
-        numDescriptors(0)
+        numDescriptors(0),
+        sourceExtended(0)
      {};
 
 };
@@ -149,6 +151,10 @@ public:
         message & frameId;
         message & numFeatures;
         message & numDescriptors;
+        if (version >= 2)
+        {
+            message & sourceExtended;
+        }
 
         const uint32_t featureDataSize = static_cast<uint32_t> (std::ceil( numFeatures*sizeof(wire::Feature) + numDescriptors*sizeof(wire::Descriptor)));
 

--- a/source/LibMultiSense/include/MultiSense/details/wire/ImageMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/ImageMessage.hh
@@ -51,7 +51,7 @@ class WIRE_HEADER_ATTRIBS_ ImageHeader {
 public:
 
 static CRL_CONSTEXPR IdType      ID      = ID_DATA_IMAGE;
-static CRL_CONSTEXPR VersionType VERSION = 2;
+static CRL_CONSTEXPR VersionType VERSION = 3;
 
 #ifdef SENSORPOD_FIRMWARE
     IdType      id;
@@ -65,6 +65,7 @@ static CRL_CONSTEXPR VersionType VERSION = 2;
     uint16_t height;
     uint32_t exposure;
     float gain;
+    uint32_t sourceExtended;
 
     ImageHeader()
         :
@@ -78,7 +79,8 @@ static CRL_CONSTEXPR VersionType VERSION = 2;
         width(0),
         height(0),
         exposure(0),
-        gain(0.0)
+        gain(0.0),
+        sourceExtended(0)
          {};
 };
 
@@ -102,7 +104,6 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
-        (void) version;
         message & source;
         message & bitsPerPixel;
         message & frameId;
@@ -130,6 +131,15 @@ public:
         {
             exposure = 0;
             gain = Default_Gain;
+        }
+
+        if (version >= 3)
+        {
+          message & sourceExtended;
+        }
+        else
+        {
+          sourceExtended = 0;
         }
     }
 };

--- a/source/LibMultiSense/include/MultiSense/details/wire/JpegMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/JpegMessage.hh
@@ -51,7 +51,7 @@ class WIRE_HEADER_ATTRIBS_ JpegImageHeader {
 public:
 
 static CRL_CONSTEXPR IdType      ID      = ID_DATA_JPEG_IMAGE;
-static CRL_CONSTEXPR VersionType VERSION = 1;
+static CRL_CONSTEXPR VersionType VERSION = 2;
 
 #ifdef SENSORPOD_FIRMWARE
     IdType      id;
@@ -64,6 +64,7 @@ static CRL_CONSTEXPR VersionType VERSION = 1;
     uint16_t height;
     uint32_t length;
     uint32_t quality;
+    uint32_t sourceExtended;
 
     JpegImageHeader() :
 #ifdef SENSORDPOD_FIRMWARE
@@ -75,7 +76,9 @@ static CRL_CONSTEXPR VersionType VERSION = 1;
         width(0),
         height(0),
         length(0),
-        quality(0) {};
+        quality(0),
+        sourceExtended(0)
+        {};
 };
 
 #ifndef SENSORPOD_FIRMWARE
@@ -98,7 +101,6 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
-        (void) version;
         message & source;
         message & frameId;
         message & width;
@@ -114,6 +116,15 @@ public:
 
             dataP = message.peek();
             message.seek(message.tell() + length);
+        }
+
+        if (version >= 2)
+        {
+          message & sourceExtended;
+        }
+        else
+        {
+          sourceExtended = 0;
         }
     }
 };

--- a/source/LibMultiSense/include/MultiSense/details/wire/Protocol.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/Protocol.hh
@@ -241,44 +241,45 @@ static CRL_CONSTEXPR IdType ID_DATA_FEATURE_DETECTOR_CONFIG            = 0x012A;
 //
 // Data sources
 
-typedef uint32_t SourceType;
+typedef uint64_t SourceType;
 
 static CRL_CONSTEXPR SourceType SOURCE_UNKNOWN                     = 0;
-static CRL_CONSTEXPR SourceType SOURCE_RAW_LEFT                    = (1U<<0);
-static CRL_CONSTEXPR SourceType SOURCE_RAW_RIGHT                   = (1U<<1);
-static CRL_CONSTEXPR SourceType SOURCE_LUMA_LEFT                   = (1U<<2);
-static CRL_CONSTEXPR SourceType SOURCE_LUMA_RIGHT                  = (1U<<3);
-static CRL_CONSTEXPR SourceType SOURCE_LUMA_RECT_LEFT              = (1U<<4);
-static CRL_CONSTEXPR SourceType SOURCE_LUMA_RECT_RIGHT             = (1U<<5);
-static CRL_CONSTEXPR SourceType SOURCE_CHROMA_LEFT                 = (1U<<6);
-static CRL_CONSTEXPR SourceType SOURCE_CHROMA_RIGHT                = (1U<<7);
-static CRL_CONSTEXPR SourceType SOURCE_CHROMA_RECT_AUX             = (1U<<8);
-static CRL_CONSTEXPR SourceType SOURCE_DISPARITY                   = (1U<<10);
-static CRL_CONSTEXPR SourceType SOURCE_DISPARITY_LEFT              = (1U<<10); // same as SOURCE_DISPARITY
-static CRL_CONSTEXPR SourceType SOURCE_DISPARITY_RIGHT             = (1U<<11);
-static CRL_CONSTEXPR SourceType SOURCE_DISPARITY_COST              = (1U<<12);
-static CRL_CONSTEXPR SourceType SOURCE_JPEG_LEFT                   = (1U<<16);
-static CRL_CONSTEXPR SourceType SOURCE_RGB_LEFT                    = (1U<<17);
-static CRL_CONSTEXPR SourceType SOURCE_FEATURE_LEFT                = (1U<<18);
-static CRL_CONSTEXPR SourceType SOURCE_FEATURE_RIGHT               = (1U<<19);
-static CRL_CONSTEXPR SourceType SOURCE_GROUND_SURFACE_SPLINE_DATA  = (1U<<20);
-static CRL_CONSTEXPR SourceType SOURCE_GROUND_SURFACE_CLASS_IMAGE  = (1U<<22);
-static CRL_CONSTEXPR SourceType SOURCE_APRILTAG_DETECTIONS         = (1U<<21);
-static CRL_CONSTEXPR SourceType SOURCE_SLB_MOTOR                   = (1U<<23);
-static CRL_CONSTEXPR SourceType SOURCE_LIDAR_SCAN                  = (1U<<24);
-static CRL_CONSTEXPR SourceType SOURCE_IMU                         = (1U<<25);
-static CRL_CONSTEXPR SourceType SOURCE_PPS                         = (1U<<26);
-static CRL_CONSTEXPR SourceType SOURCE_RAW_AUX                     = (1U<<27);
-static CRL_CONSTEXPR SourceType SOURCE_LUMA_AUX                    = (1U<<28);
-static CRL_CONSTEXPR SourceType SOURCE_LUMA_RECT_AUX               = (1U<<29);
-static CRL_CONSTEXPR SourceType SOURCE_CHROMA_AUX                  = (1U<<30);
-static CRL_CONSTEXPR SourceType SOURCE_DISPARITY_AUX               = (1U<<31);
-static CRL_CONSTEXPR SourceType SOURCE_COMPRESSED_LEFT             = (1U<<9);
-static CRL_CONSTEXPR SourceType SOURCE_COMPRESSED_RIGHT            = (1U<<13);
-static CRL_CONSTEXPR SourceType SOURCE_COMPRESSED_AUX              = (1U<<14);
-static CRL_CONSTEXPR SourceType SOURCE_COMPRESSED_RECTIFIED_LEFT   = (1U<<15);
-static CRL_CONSTEXPR SourceType SOURCE_COMPRESSED_RECTIFIED_RIGHT  = (1U<<16); // same as SOURCE_JPEG_LEFT
-static CRL_CONSTEXPR SourceType SOURCE_COMPRESSED_RECTIFIED_AUX    = (1U<<17); // same as SOURCE_RGB_LEFT
+static CRL_CONSTEXPR SourceType SOURCE_RAW_LEFT                    = (1ull<<0);
+static CRL_CONSTEXPR SourceType SOURCE_RAW_RIGHT                   = (1ull<<1);
+static CRL_CONSTEXPR SourceType SOURCE_LUMA_LEFT                   = (1ull<<2);
+static CRL_CONSTEXPR SourceType SOURCE_LUMA_RIGHT                  = (1ull<<3);
+static CRL_CONSTEXPR SourceType SOURCE_LUMA_RECT_LEFT              = (1ull<<4);
+static CRL_CONSTEXPR SourceType SOURCE_LUMA_RECT_RIGHT             = (1ull<<5);
+static CRL_CONSTEXPR SourceType SOURCE_CHROMA_LEFT                 = (1ull<<6);
+static CRL_CONSTEXPR SourceType SOURCE_CHROMA_RIGHT                = (1ull<<7);
+static CRL_CONSTEXPR SourceType SOURCE_CHROMA_RECT_AUX             = (1ull<<8);
+static CRL_CONSTEXPR SourceType SOURCE_DISPARITY                   = (1ull<<10);
+static CRL_CONSTEXPR SourceType SOURCE_DISPARITY_LEFT              = (1ull<<10); // same as SOURCE_DISPARITY
+static CRL_CONSTEXPR SourceType SOURCE_DISPARITY_RIGHT             = (1ull<<11);
+static CRL_CONSTEXPR SourceType SOURCE_DISPARITY_COST              = (1ull<<12);
+static CRL_CONSTEXPR SourceType SOURCE_JPEG_LEFT                   = (1ull<<16);
+static CRL_CONSTEXPR SourceType SOURCE_RGB_LEFT                    = (1ull<<17);
+static CRL_CONSTEXPR SourceType SOURCE_FEATURE_LEFT                = (1ull<<18);
+static CRL_CONSTEXPR SourceType SOURCE_FEATURE_RIGHT               = (1ull<<19);
+static CRL_CONSTEXPR SourceType SOURCE_FEATURE_AUX                 = (1ull<<32);
+static CRL_CONSTEXPR SourceType SOURCE_GROUND_SURFACE_SPLINE_DATA  = (1ull<<20);
+static CRL_CONSTEXPR SourceType SOURCE_GROUND_SURFACE_CLASS_IMAGE  = (1ull<<22);
+static CRL_CONSTEXPR SourceType SOURCE_APRILTAG_DETECTIONS         = (1ull<<21);
+static CRL_CONSTEXPR SourceType SOURCE_SLB_MOTOR                   = (1ull<<23);
+static CRL_CONSTEXPR SourceType SOURCE_LIDAR_SCAN                  = (1ull<<24);
+static CRL_CONSTEXPR SourceType SOURCE_IMU                         = (1ull<<25);
+static CRL_CONSTEXPR SourceType SOURCE_PPS                         = (1ull<<26);
+static CRL_CONSTEXPR SourceType SOURCE_RAW_AUX                     = (1ull<<27);
+static CRL_CONSTEXPR SourceType SOURCE_LUMA_AUX                    = (1ull<<28);
+static CRL_CONSTEXPR SourceType SOURCE_LUMA_RECT_AUX               = (1ull<<29);
+static CRL_CONSTEXPR SourceType SOURCE_CHROMA_AUX                  = (1ull<<30);
+static CRL_CONSTEXPR SourceType SOURCE_DISPARITY_AUX               = (1ull<<31);
+static CRL_CONSTEXPR SourceType SOURCE_COMPRESSED_LEFT             = (1ull<<9);
+static CRL_CONSTEXPR SourceType SOURCE_COMPRESSED_RIGHT            = (1ull<<13);
+static CRL_CONSTEXPR SourceType SOURCE_COMPRESSED_AUX              = (1ull<<14);
+static CRL_CONSTEXPR SourceType SOURCE_COMPRESSED_RECTIFIED_LEFT   = (1ull<<15);
+static CRL_CONSTEXPR SourceType SOURCE_COMPRESSED_RECTIFIED_RIGHT  = (1ull<<16); // same as SOURCE_JPEG_LEFT
+static CRL_CONSTEXPR SourceType SOURCE_COMPRESSED_RECTIFIED_AUX    = (1ull<<17); // same as SOURCE_RGB_LEFT
 
 static CRL_CONSTEXPR SourceType SOURCE_IMAGES            = (SOURCE_RAW_LEFT        |
                                                             SOURCE_RAW_RIGHT       |

--- a/source/LibMultiSense/include/MultiSense/details/wire/StreamControlMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/StreamControlMessage.hh
@@ -47,7 +47,7 @@ namespace wire {
 class StreamControl {
 public:
     static CRL_CONSTEXPR IdType      ID      = ID_CMD_STREAM_CONTROL;
-    static CRL_CONSTEXPR VersionType VERSION = 1;
+    static CRL_CONSTEXPR VersionType VERSION = 2;
 
     //
     // Set modify mask bit high to have the device
@@ -80,9 +80,23 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
-        (void) version;
-        message & modifyMask;
-        message & controlMask;
+
+        uint32_t modifyMaskLow   = (uint32_t)(modifyMask>>0);
+        uint32_t modifyMaskHigh  = (uint32_t)((modifyMask&0xFFFFFFFF00000000ull)>>32);
+        uint32_t controlMaskLow  = (uint32_t)(controlMask>>0);
+        uint32_t controlMaskHigh = (uint32_t)((controlMask&0xFFFFFFFF00000000ull)>>32);
+
+        message & modifyMaskLow;
+        if (version >= 2)
+        {
+          message & modifyMaskHigh;
+        }
+
+        message & controlMaskLow;
+        if (version >= 2)
+        {
+          message & controlMaskHigh;
+        }
     }
 };
 

--- a/source/LibMultiSense/include/MultiSense/details/wire/StreamControlMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/StreamControlMessage.hh
@@ -81,22 +81,44 @@ public:
                        const VersionType version)
     {
 
-        uint32_t modifyMaskLow   = (uint32_t)(modifyMask>>0);
-        uint32_t modifyMaskHigh  = (uint32_t)((modifyMask&0xFFFFFFFF00000000ull)>>32);
-        uint32_t controlMaskLow  = (uint32_t)(controlMask>>0);
-        uint32_t controlMaskHigh = (uint32_t)((controlMask&0xFFFFFFFF00000000ull)>>32);
+        uint32_t modifyMaskLow = 0;
+        uint32_t modifyMaskHigh = 0;
+        uint32_t controlMaskLow = 0;
+        uint32_t controlMaskHigh = 0;
 
-        message & modifyMaskLow;
-        if (version >= 2)
-        {
-          message & modifyMaskHigh;
+        if (typeid(Archive) == typeid(utility::BufferStreamWriter)) {
+
+            modifyMaskLow   = (uint32_t)(modifyMask>>0);
+            modifyMaskHigh  = (uint32_t)((modifyMask&0xFFFFFFFF00000000ull)>>32);
+            controlMaskLow  = (uint32_t)(controlMask>>0);
+            controlMaskHigh = (uint32_t)((controlMask&0xFFFFFFFF00000000ull)>>32);
+
+            message & modifyMaskLow;
+            message & controlMaskLow;
+
+            if (version >= 2)
+            {
+                message & modifyMaskHigh;
+                message & controlMaskHigh;
+            }
+
+        } else {
+
+
+            message & modifyMaskLow;
+            message & controlMaskLow;
+
+            if (version >= 2)
+            {
+                message & modifyMaskHigh;
+                message & controlMaskHigh;
+            }
+
+            modifyMask  = ((uint64_t)modifyMaskHigh) << 32 | modifyMaskLow;
+            controlMask = ((uint64_t)controlMaskHigh) << 32 | controlMaskLow;
+
         }
 
-        message & controlMaskLow;
-        if (version >= 2)
-        {
-          message & controlMaskHigh;
-        }
     }
 };
 

--- a/source/LibMultiSense/include/MultiSense/details/wire/SysDeviceModesMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/SysDeviceModesMessage.hh
@@ -111,6 +111,10 @@ public:
             {
               message & m.extendedDataSources;
             }
+            else
+            {
+              m.extendedDataSources = 0;
+            }
         }
     }
 };

--- a/source/LibMultiSense/include/MultiSense/details/wire/SysDeviceModesMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/SysDeviceModesMessage.hh
@@ -50,21 +50,26 @@ public:
     uint32_t height;
     uint32_t supportedDataSources;
     uint32_t disparities;
+    uint32_t extendedDataSources;
 
     DeviceMode(uint32_t w=0,
                uint32_t h=0,
-               uint32_t s=0,
+               uint64_t s=0,
                uint32_t d=0) :
         width(w),
         height(h),
-        supportedDataSources(s),
-        disparities(d) {};
+        disparities(d)
+        {
+            supportedDataSources = (uint32_t) (s & 0xFFFFFFFFull);
+            extendedDataSources =  (uint32_t) ((s & 0xFFFFFFFF00000000ull) >> 32);
+        };
+
 };
 
 class SysDeviceModes {
 public:
     static CRL_CONSTEXPR IdType      ID      = ID_DATA_SYS_DEVICE_MODES;
-    static CRL_CONSTEXPR VersionType VERSION = 2;
+    static CRL_CONSTEXPR VersionType VERSION = 3;
 
     //
     // Available formats
@@ -102,6 +107,10 @@ public:
             message & m.height;
             message & m.supportedDataSources;
             message & m.disparities; // was 'flags' in pre v2.3
+            if (version >= 3)
+            {
+              message & m.extendedDataSources;
+            }
         }
     }
 };

--- a/source/LibMultiSense/include/MultiSense/details/wire/SysDeviceModesMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/SysDeviceModesMessage.hh
@@ -109,11 +109,11 @@ public:
             message & m.disparities; // was 'flags' in pre v2.3
             if (version >= 3)
             {
-              message & m.extendedDataSources;
+                message & m.extendedDataSources;
             }
             else
             {
-              m.extendedDataSources = 0;
+                m.extendedDataSources = 0;
             }
         }
     }


### PR DESCRIPTION
Fundamentally, this allows the Source_Feature_Aux to be enabled in stream control.
But adding that stream type exceeded the 32-bit threshold set by the SourceType and the DataSource.
This also allows support for the 32-bit SourceType and DataSource elements to be extended to 64-bit, without breaking backward compatability. This will free-up an additional 31 potential Source Types to be used by the developers discretion.
This uses the Messages Version Number to maintain backward compatability.
I have tested against the following cases.
 - Old Firmware - New Client
 - New Firmware - Old Client
 - New Firmware - New Client
