### PR TITLE
Added controls for setting gainMax

### DIFF
--- a/source/LibMultiSense/details/public.cc
+++ b/source/LibMultiSense/details/public.cc
@@ -917,6 +917,7 @@ Status impl::getImageConfig(image::Config& config)
     a.setCameraProfile(static_cast<CameraProfile>(d.cameraProfile));
 
     a.setGamma(d.gamma);
+    a.setGainMax(d.gainMax);
 
     return Status_Ok;
 }
@@ -970,6 +971,7 @@ Status impl::getAuxImageConfig(image::AuxConfig& config)
     a.enableSharpening(d.sharpeningEnable);
     a.setSharpeningPercentage(d.sharpeningPercentage);
     a.setSharpeningLimit(d.sharpeningLimit);
+    a.setGainMax(d.gainMax);
 
     return Status_Ok;
 }
@@ -1018,6 +1020,7 @@ Status impl::setImageConfig(const image::Config& c)
     cmd.cameraProfile    = static_cast<uint32_t>(c.cameraProfile());
 
     cmd.gamma = c.gamma();
+    cmd.gainMax = c.gainMax();
 
     return waitAck(cmd);
 }
@@ -1053,6 +1056,7 @@ Status impl::setAuxImageConfig(const image::AuxConfig& c)
     cmd.sharpeningEnable = c.enableSharpening();
     cmd.sharpeningPercentage = c.sharpeningPercentage();
     cmd.sharpeningLimit = c.sharpeningLimit();
+    cmd.gainMax = c.gainMax();
 
     return waitAck(cmd);
 }

--- a/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
@@ -43,7 +43,6 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
-#include <limits>
 
 #if defined (CRL_HAVE_CONSTEXPR)
 #define CRL_CONSTEXPR constexpr
@@ -218,6 +217,9 @@ static CRL_CONSTEXPR RemoteHeadChannel Remote_Head_2           = 2;
 static CRL_CONSTEXPR RemoteHeadChannel Remote_Head_3           = 3;
 /** Invalid Remote Head position*/
 static CRL_CONSTEXPR RemoteHeadChannel Remote_Head_Invalid     = SHRT_MAX;
+
+/** The maximum gain supported*/
+static CRL_CONSTEXPR float ImagerGainMax = 1000.0f;
 
 /**
  * Remote head sync group defines a group of remote heads which will have their
@@ -1797,7 +1799,7 @@ public:
                m_profile(User_Control),
                m_gamma(2.0),
                m_sharpeningEnable(false), m_sharpeningPercentage(0.0f), m_sharpeningLimit(0),
-               m_gainMax(std::numeric_limits<float>::max()),
+               m_gainMax(ImagerGainMax),
                m_fx(0), m_fy(0), m_cx(0), m_cy(0) {};
 private:
 

--- a/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
@@ -43,6 +43,7 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include <limits>
 
 #if defined (CRL_HAVE_CONSTEXPR)
 #define CRL_CONSTEXPR constexpr
@@ -1003,6 +1004,16 @@ public:
      */
     void setGamma(const float g) { m_gamma = g; };
 
+    /**
+     * Set the auto exposure gain max.
+     *
+     * This can be used to add an additional clamp to auto exposure which
+     * would limit the maximum analog gain set by the auto exposure algorithm.
+     *
+     * @param g the max gain constant applied to the camera sources
+     */
+    void setGainMax(const float g) { m_gainMax = g; };
+
 
     //
     // Query
@@ -1197,6 +1208,13 @@ public:
      */
     float gamma() const { return m_gamma; };
 
+    /**
+     * Query the gain maximum allowed in the camera.
+     *
+     * @return A value within the range of 1.0 - Max Gain of the imager
+     */
+    float gainMax() const { return m_gainMax; };
+
     //
     // Query camera calibration (read-only)
     //
@@ -1338,6 +1356,7 @@ private:
     bool     m_hdrEnabled;
     CameraProfile m_profile;
     float    m_gamma;
+    float    m_gainMax;
 
 protected:
 
@@ -1499,7 +1518,6 @@ public:
      */
     void setGamma(const float g) { m_gamma = g; };
 
-
     /**
      * Enable sharpening for the aux luma channel.
      *
@@ -1525,6 +1543,17 @@ public:
      */
 
     void setSharpeningLimit(const uint8_t &s)    { m_sharpeningLimit  = s; };
+
+    /**
+     * Set the auto exposure gain max.
+     *
+     * This can be used to add an additional clamp to auto exposure which
+     * would limit the maximum analog gain set by the auto exposure algorithm.
+     *
+     * @param g the max gain constant applied to the camera sources
+     */
+    void setGainMax(const float g) { m_gainMax = g; };
+
 
     //
     // Query
@@ -1751,6 +1780,13 @@ public:
     uint8_t sharpeningLimit() const { return m_sharpeningLimit; };
 
     /**
+     * Query the gain maximum allowed in the camera.
+     *
+     * @return A value within the range of 1.0 - Max Gain of the imager
+     */
+    float gainMax() const { return m_gainMax; };
+
+    /**
      * Default constructor for a image configuration. Initializes all image
      * configuration members to their default values
      */
@@ -1761,6 +1797,7 @@ public:
                m_profile(User_Control),
                m_gamma(2.0),
                m_sharpeningEnable(false), m_sharpeningPercentage(0.0f), m_sharpeningLimit(0),
+               m_gainMax(std::numeric_limits<float>::max()),
                m_fx(0), m_fy(0), m_cx(0), m_cy(0) {};
 private:
 
@@ -1777,7 +1814,7 @@ private:
     bool     m_sharpeningEnable;
     float    m_sharpeningPercentage;
     uint8_t  m_sharpeningLimit;
-
+    float    m_gainMax;
 protected:
 
     float    m_fx, m_fy, m_cx, m_cy;

--- a/source/LibMultiSense/include/MultiSense/details/wire/AuxCamConfigMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/AuxCamConfigMessage.hh
@@ -51,7 +51,7 @@ namespace wire {
 class AuxCamConfig {
 public:
     static CRL_CONSTEXPR IdType      ID      = ID_DATA_CAM_AUX_CONFIG;
-    static CRL_CONSTEXPR VersionType VERSION = 1;
+    static CRL_CONSTEXPR VersionType VERSION = 2;
 
     //
     // Parameters representing the current camera configuration
@@ -92,6 +92,8 @@ public:
     float sharpeningPercentage;
     uint8_t sharpeningLimit;
 
+    float gainMax;
+
     //
     // Constructors
 
@@ -122,7 +124,8 @@ public:
         gamma(Default_Gamma),
         sharpeningEnable(false),
         sharpeningPercentage(0.0f),
-        sharpeningLimit(0)
+        sharpeningLimit(0),
+        gainMax(std::numeric_limits<float>::max())
         {};
 
     //
@@ -168,6 +171,17 @@ public:
         message & sharpeningEnable;
         message & sharpeningPercentage;
         message & sharpeningLimit;
+
+        //
+        // version 2 additions
+        if (version >= 2)
+        {
+            message & gainMax;
+        }
+        else
+        {
+            gainMax = std::numeric_limits<float>::max();
+        }
 
     }
 };

--- a/source/LibMultiSense/include/MultiSense/details/wire/AuxCamConfigMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/AuxCamConfigMessage.hh
@@ -125,7 +125,7 @@ public:
         sharpeningEnable(false),
         sharpeningPercentage(0.0f),
         sharpeningLimit(0),
-        gainMax(std::numeric_limits<float>::max())
+        gainMax(ImagerGainMax)
         {};
 
     //
@@ -180,7 +180,7 @@ public:
         }
         else
         {
-            gainMax = std::numeric_limits<float>::max();
+            gainMax = ImagerGainMax;
         }
 
     }

--- a/source/LibMultiSense/include/MultiSense/details/wire/AuxCamControlMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/AuxCamControlMessage.hh
@@ -142,7 +142,7 @@ public:
         }
         else
         {
-            gainMax = std::numeric_limits<float>::max();
+            gainMax = ImagerGainMax;
         }
 
     }

--- a/source/LibMultiSense/include/MultiSense/details/wire/AuxCamControlMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/AuxCamControlMessage.hh
@@ -51,7 +51,7 @@ namespace wire {
 class AuxCamControl {
 public:
     static CRL_CONSTEXPR IdType      ID      = ID_CMD_CAM_AUX_CONTROL;
-    static CRL_CONSTEXPR VersionType VERSION = 1;
+    static CRL_CONSTEXPR VersionType VERSION = 2;
 
     //
     // Parameters representing the current camera configuration
@@ -85,6 +85,8 @@ public:
     bool  sharpeningEnable;
     float sharpeningPercentage;
     uint8_t sharpeningLimit;
+
+    float gainMax;
 
 
     //
@@ -131,6 +133,17 @@ public:
         message & sharpeningEnable;
         message & sharpeningPercentage;
         message & sharpeningLimit;
+
+        //
+        // version 2 additions
+        if (version >= 2)
+        {
+            message & gainMax;
+        }
+        else
+        {
+            gainMax = std::numeric_limits<float>::max();
+        }
 
     }
 };

--- a/source/LibMultiSense/include/MultiSense/details/wire/CamConfigMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/CamConfigMessage.hh
@@ -52,7 +52,7 @@ namespace wire {
 class CamConfig {
 public:
     static CRL_CONSTEXPR IdType      ID      = ID_DATA_CAM_CONFIG;
-    static CRL_CONSTEXPR VersionType VERSION = 9;
+    static CRL_CONSTEXPR VersionType VERSION = 10;
 
     //
     // Parameters representing the current camera configuration
@@ -127,6 +127,10 @@ public:
     uint8_t sharpeningLimit;
 
     //
+    // Version 10 additions
+    float gainMax;
+
+    //
     // Constructors
 
     CamConfig(utility::BufferStreamReader&r, VersionType v) {serialize(r,v);};
@@ -169,7 +173,8 @@ public:
         gamma(Default_Gamma),
         sharpeningEnable(false),
         sharpeningPercentage(0.0f),
-        sharpeningLimit(0)
+        sharpeningLimit(0),
+        gainMax(std::numeric_limits<float>::max())
         {};
 
     //
@@ -273,15 +278,24 @@ public:
 
         if (version >= 9)
         {
-          message & sharpeningEnable;
-          message & sharpeningPercentage;
-          message & sharpeningLimit;
+            message & sharpeningEnable;
+            message & sharpeningPercentage;
+            message & sharpeningLimit;
         }
         else
         {
-          sharpeningEnable = false;
-          sharpeningPercentage = 0.0f;
-          sharpeningLimit = 0;
+            sharpeningEnable = false;
+            sharpeningPercentage = 0.0f;
+            sharpeningLimit = 0;
+        }
+
+        if (version >= 10)
+        {
+            message & gainMax;
+        }
+        else
+        {
+            gainMax = std::numeric_limits<float>::max();
         }
 
     }

--- a/source/LibMultiSense/include/MultiSense/details/wire/CamConfigMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/CamConfigMessage.hh
@@ -174,7 +174,7 @@ public:
         sharpeningEnable(false),
         sharpeningPercentage(0.0f),
         sharpeningLimit(0),
-        gainMax(std::numeric_limits<float>::max())
+        gainMax(ImagerGainMax)
         {};
 
     //
@@ -295,7 +295,7 @@ public:
         }
         else
         {
-            gainMax = std::numeric_limits<float>::max();
+            gainMax = ImagerGainMax;
         }
 
     }

--- a/source/LibMultiSense/include/MultiSense/details/wire/CamControlMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/CamControlMessage.hh
@@ -232,7 +232,7 @@ public:
         }
         else
         {
-            gainMax = std::numeric_limits<float>::max();
+            gainMax = ImagerGainMax;
         }
 
     }

--- a/source/LibMultiSense/include/MultiSense/details/wire/CamControlMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/CamControlMessage.hh
@@ -52,7 +52,7 @@ namespace wire {
 class CamControl {
 public:
     static CRL_CONSTEXPR IdType      ID      = ID_CMD_CAM_CONTROL;
-    static CRL_CONSTEXPR VersionType VERSION = 9;
+    static CRL_CONSTEXPR VersionType VERSION = 10;
 
     //
     // Parameters representing the current camera configuration
@@ -118,6 +118,10 @@ public:
     bool  sharpeningEnable; // Deprecated
     float sharpeningPercentage; // Deprecated
     uint8_t sharpeningLimit; // Deprecated
+
+    //
+    // Additions in version 10
+    float gainMax;
 
 
     //
@@ -220,6 +224,15 @@ public:
             sharpeningEnable = false;
             sharpeningPercentage = 0.0f;
             sharpeningLimit = 0;
+        }
+
+        if (version >= 10)
+        {
+            message & gainMax;
+        }
+        else
+        {
+            gainMax = std::numeric_limits<float>::max();
         }
 
     }


### PR DESCRIPTION
Provides a control and response for auto exposure maximum gain for both the stereo pair, as well as the aux imager.
This provides a limit on the maximum amount of gain the auto exposure algorithm allows.
This is a request based on a customer need to reduce the artifacts within a dark scene.