### PR TITLE
Fixed broken backwards compatability

### DIFF
--- a/source/LibMultiSense/include/MultiSense/details/wire/SysDeviceModesMessage.hh
+++ b/source/LibMultiSense/include/MultiSense/details/wire/SysDeviceModesMessage.hh
@@ -90,7 +90,6 @@ public:
         void serialize(Archive&          message,
                        const VersionType version)
     {
-        (void) version;
         uint32_t length = static_cast<uint32_t> (modes.size());
         message & length;
         modes.resize(length);
@@ -107,6 +106,10 @@ public:
             message & m.height;
             message & m.supportedDataSources;
             message & m.disparities; // was 'flags' in pre v2.3
+        }
+
+        for(uint32_t i=0; i<length; i++) {
+            DeviceMode& m = modes[i];
             if (version >= 3)
             {
                 message & m.extendedDataSources;


### PR DESCRIPTION
This addresses the broken backward compatability introduced in the extension of the DataSource type.
The serialize routine which runs for the BufferStreamWriter makes this compatable for both pre 64-bit client and post 64-bit clients.
