### PR TITLE
Fix sscanf buffer size error

### DIFF
--- a/source/Utilities/DeviceInfoUtility/DeviceInfoUtility.cc
+++ b/source/Utilities/DeviceInfoUtility/DeviceInfoUtility.cc
@@ -165,8 +165,8 @@ bool parseFile(const std::string& fileName,
 
     while (!feof(fP)) {
 
-        char  lineP[512] = {0};
-        char  tempP[512] = {0};
+        char  lineP[513] = {0};
+        char  tempP[513] = {0};
         int   tempi;
         float tempf;
 


### PR DESCRIPTION
When compiling with `-Werror,-Wfortify-source`, the following error is thrown. Expanding the buffer by 1 (I believe for the null terminator) resolves this error

```
/source/Utilities/DeviceInfoUtility/DeviceInfoUtility.cc:222:9: error: 'sscanf' may overflow; destination buffer in argument 3 has size 512, but the corresponding specifier may require size 513 [-Werror,-Wfortify-source]
         CASE_STR("deviceName: ",              info.name);
         ^
```