### PR TITLE
Set Default MTU to 1500

### DIFF
--- a/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
@@ -436,7 +436,7 @@ namespace image {
  *      crl::multisense::Channel* channel;
  *      channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *      channel->setMtu(7200);
+ *      channel->setMtu(1500);
  *
  *      try
  *      {
@@ -722,7 +722,7 @@ public:
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     //
  *     // Create a imageConfig instance to store the queried configuration
@@ -754,7 +754,7 @@ public:
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     //
  *     // Create a imageConfig instance to store the queried configuration
@@ -1840,7 +1840,7 @@ protected:
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     //
  *     // Create a image::Calibration instance to store the queried calibration
@@ -1872,7 +1872,7 @@ protected:
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     //
  *     // Create a image::Calibration instance to store the queried calibration
@@ -1964,7 +1964,7 @@ public:
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     //
  *     // Create a histogram instance to store histogram data
@@ -2124,7 +2124,7 @@ typedef void (*Callback)(const Header& header,
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     //
  *     // Create a lidarCalibration instance to store the queried laser calibration
@@ -2156,7 +2156,7 @@ typedef void (*Callback)(const Header& header,
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     //
  *     // Create a lidarCalibration instance to store the new laser calibration
@@ -2225,7 +2225,7 @@ static CRL_CONSTEXPR float    MAX_DUTY_CYCLE = 100.0;
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     //
  *     // Create a lightingConfig instance to store our queried lighting configuration
@@ -2257,7 +2257,7 @@ static CRL_CONSTEXPR float    MAX_DUTY_CYCLE = 100.0;
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     //
  *     // Create a lightingConfig instance to store our queried lighting configuration
@@ -2507,7 +2507,7 @@ private:
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     //
  *     // Create a lightingConfig instance to store our queried lighting configuration
@@ -2677,7 +2677,7 @@ typedef void (*Callback)(const Header& header,
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     //
  *     // Create a vector of IMU info instances to store information for
@@ -2754,7 +2754,7 @@ public:
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     //
  *     // Create local variables to store the information returned by
@@ -2788,7 +2788,7 @@ public:
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     //
  *     // Create a vector of IMU configurations to store the queried IMU configuration
@@ -3080,7 +3080,7 @@ namespace system {
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     std::vector<crl::multisense::system::DeviceMode> deviceModeVect;
  *
@@ -3140,7 +3140,7 @@ public:
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     //
  *     // Create a VersionInfo instance to store the sensors version info
@@ -3225,7 +3225,7 @@ public:
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     //
  *     // Create a instance of Device info to store the sensors device information
@@ -3374,7 +3374,7 @@ public:
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     //
  *     // Create a instance of NetworkConfig to store the sensor's network configuration
@@ -3406,7 +3406,7 @@ public:
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     //
  *     // Create a new instance of a Network configuration with the new desired
@@ -3477,7 +3477,7 @@ public:
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     //
  *     // Create a instance of StatusMessage to store the sensor's status
@@ -3600,7 +3600,7 @@ class MULTISENSE_API StatusMessage {
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     //
  *     // Create a instance of ExternalCalibration to store the device's imager
@@ -3633,7 +3633,7 @@ class MULTISENSE_API StatusMessage {
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     //
  *     // Create a instance of ExternalCalibration to store the device's imager
@@ -3707,7 +3707,7 @@ class MULTISENSE_API ExternalCalibration {
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     //
  *     // Create a instance of GroundSurfaceParams to store the device's params
@@ -3854,7 +3854,7 @@ class MULTISENSE_API GroundSurfaceParams {
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     //
  *     // Create a instance of ApriltagParams to store the device's params
@@ -3953,7 +3953,7 @@ class MULTISENSE_API ApriltagParams {
  *     crl::multisense::Channel* channel;
  *     channel = crl::multisense::Channel::Create("10.66.171.21");
  *
- *     channel->setMtu(7200);
+ *     channel->setMtu(1500);
  *
  *     FeatureDetectorConfig fcfg;
  *

--- a/source/Utilities/AprilTagTestUtility/AprilTagTestUtility.cc
+++ b/source/Utilities/AprilTagTestUtility/AprilTagTestUtility.cc
@@ -70,7 +70,7 @@ void usage(const char *programNameP)
     std::cerr << "USAGE: " << programNameP << " [<options>]" << std::endl;
     std::cerr << "Where <options> are:" << std::endl;
     std::cerr << "\t-a <ip_address>    : IPV4 address (default=10.66.171.21)" << std::endl;
-    std::cerr << "\t-m <mtu>           : default=7200" << std::endl;
+    std::cerr << "\t-m <mtu>           : default=1500" << std::endl;
     std::cerr << "\t-f <log_file>      : FILE to log IMU data (stdout by default)" << std::endl;
 
     exit(1);
@@ -136,7 +136,7 @@ int main(int    argc,
          char **argvPP)
 {
     std::string currentAddress = "10.66.171.21";
-    uint32_t    mtu            = 7200;
+    uint32_t    mtu            = 1500;
 
     crl::multisense::CameraProfile  profile = crl::multisense::User_Control;
     crl::multisense::system::ApriltagParams params;

--- a/source/Utilities/ColorImageUtility/ColorImage.cc
+++ b/source/Utilities/ColorImageUtility/ColorImage.cc
@@ -76,7 +76,7 @@ void usage(const char* programNameP)
     std::cerr << "USAGE: " << programNameP << " [<options>]" << std::endl;
     std::cerr << "Where <options> are:" << std::endl;
     std::cerr << "\t-a <current_address>    : CURRENT IPV4 address (default=10.66.171.21)" << std::endl;
-    std::cerr << "\t-m <mtu>                : CURRENT MTU (default=7200)" << std::endl;
+    std::cerr << "\t-m <mtu>                : CURRENT MTU (default=1500)" << std::endl;
     std::cerr << "\t-s <color_source>       : LEFT,RIGHT,AUX (default=aux)" << std::endl;
 
     exit(1);
@@ -187,7 +187,7 @@ int main(int    argc,
         char** argvPP)
 {
     std::string currentAddress = "10.66.171.21";
-    int32_t mtu = 7200;
+    int32_t mtu = 1500;
     std::pair<DataSource, DataSource> userSource{ Source_Chroma_Rectified_Aux, Source_Luma_Rectified_Aux };
 
 #if WIN32

--- a/source/Utilities/DepthImageUtility/DepthImageUtility.cc
+++ b/source/Utilities/DepthImageUtility/DepthImageUtility.cc
@@ -76,7 +76,7 @@ void usage(const char *programNameP)
     std::cerr << "USAGE: " << programNameP << " [<options>]" << std::endl;
     std::cerr << "Where <options> are:" << std::endl;
     std::cerr << "\t-a <current_address>    : CURRENT IPV4 address (default=10.66.171.21)" << std::endl;
-    std::cerr << "\t-m <mtu>                : CURRENT MTU (default=7200)" << std::endl;
+    std::cerr << "\t-m <mtu>                : CURRENT MTU (default=1500)" << std::endl;
     std::cerr << "\t-c                      : Save color images and depth in the color image frame" << std::endl;
 
     exit(1);
@@ -313,7 +313,7 @@ int main(int    argc,
          char **argvPP)
 {
     std::string currentAddress = "10.66.171.21";
-    int32_t mtu = 7200;
+    int32_t mtu = 1500;
     bool useColor = false;
 
 #if WIN32

--- a/source/Utilities/FeatureDetectorUtility/FeatureDetectorUtility.cc
+++ b/source/Utilities/FeatureDetectorUtility/FeatureDetectorUtility.cc
@@ -91,7 +91,7 @@ void usage(const char *programNameP)
     std::cerr << "USAGE: " << programNameP << " [<options>]" << std::endl;
     std::cerr << "Where <options> are:" << std::endl;
     std::cerr << "\t-a <current_address>    : CURRENT IPV4 address (default=10.66.171.21)" << std::endl;
-    std::cerr << "\t-m <mtu>                : MTU to set the camera to (default=7200)" << std::endl;
+    std::cerr << "\t-m <mtu>                : MTU to set the camera to (default=1500)" << std::endl;
     std::cerr << "\t-r <head_id>    : remote head ID (default=0)" << std::endl;
 
     exit(1);
@@ -390,7 +390,7 @@ int main(int    argc,
          char **argvPP)
 {
     std::string currentAddress = "10.66.171.21";
-    int32_t mtu = 7200;
+    int32_t mtu = 1500;
     RemoteHeadChannel head_id = Remote_Head_VPB;
 
 #if WIN32

--- a/source/Utilities/ImuTestUtility/ImuTestUtility.cc
+++ b/source/Utilities/ImuTestUtility/ImuTestUtility.cc
@@ -76,7 +76,7 @@ void usage(const char *programNameP)
     std::cerr << "USAGE: " << programNameP << " [<options>]" << std::endl;
     std::cerr << "Where <options> are:" << std::endl;
     std::cerr << "\t-a <ip_address>    : IPV4 address (default=10.66.171.21)" << std::endl;
-    std::cerr << "\t-m <mtu>           : default=7200" << std::endl;
+    std::cerr << "\t-m <mtu>           : default=1500" << std::endl;
     std::cerr << "\t-f <log_file>      : FILE to log IMU data (stdout by default)" << std::endl;
 
     exit(1);
@@ -139,7 +139,7 @@ int main(int    argc,
 {
     std::string currentAddress = "10.66.171.21";
     const char *logFileNameP   = NULL;
-    uint32_t    mtu            = 7200;
+    uint32_t    mtu            = 1500;
 
 #if WIN32
     SetConsoleCtrlHandler (signalHandler, TRUE);

--- a/source/Utilities/PointCloudUtility/PointCloudUtility.cc
+++ b/source/Utilities/PointCloudUtility/PointCloudUtility.cc
@@ -74,7 +74,7 @@ void usage(const char *programNameP)
     std::cerr << "USAGE: " << programNameP << " [<options>]" << std::endl;
     std::cerr << "Where <options> are:" << std::endl;
     std::cerr << "\t-a <current_address>    : CURRENT IPV4 address (default=10.66.171.21)" << std::endl;
-    std::cerr << "\t-m <mtu>                : CURRENT MTU (default=7200)" << std::endl;
+    std::cerr << "\t-m <mtu>                : CURRENT MTU (default=1500)" << std::endl;
     std::cerr << "\t-d <min_disparity>      : CURRENT MINIMUM DISPARITY (default=5.0)" << std::endl;
 
     exit(1);
@@ -282,7 +282,7 @@ int main(int    argc,
          char **argvPP)
 {
     std::string currentAddress = "10.66.171.21";
-    int32_t mtu = 7200;
+    int32_t mtu = 1500;
     double minDisparity = 5.0;
 
 #if WIN32

--- a/source/Utilities/SaveImageUtility/SaveImageUtility.cc
+++ b/source/Utilities/SaveImageUtility/SaveImageUtility.cc
@@ -83,7 +83,7 @@ void usage(const char *programNameP)
     std::cerr << "USAGE: " << programNameP << " [<options>]" << std::endl;
     std::cerr << "Where <options> are:" << std::endl;
     std::cerr << "\t-a <current_address>    : CURRENT IPV4 address (default=10.66.171.21)" << std::endl;
-    std::cerr << "\t-m <mtu>                : MTU to set the camera to (default=7200)" << std::endl;
+    std::cerr << "\t-m <mtu>                : MTU to set the camera to (default=1500)" << std::endl;
     std::cerr << "\t-r <head_id>    : remote head ID (default=0)" << std::endl;
 
     exit(1);
@@ -287,7 +287,7 @@ int main(int    argc,
          char **argvPP)
 {
     std::string currentAddress = "10.66.171.21";
-    int32_t mtu = 7200;
+    int32_t mtu = 1500;
     RemoteHeadChannel head_id = Remote_Head_VPB;
 
 #if WIN32


### PR DESCRIPTION
This PR modifies the default mtu from 7200 to 1500 for all tools and examples. Jumbo frame support regularly trips up users and prevents them from being able to stream images. The performance loss between 1500 and 7200 is theoretically in the low single digit percentages, so it is not worth the trouble to have examples enforcing jumbo frame support

This should significantly improve most user's ability to get a camera running for the first time, and reduce the amount of debugging it takes to understand why a camera will not stream images