### PR TITLE
Small performance fixes

### DIFF
--- a/source/LibMultiSense/details/legacy/channel.cc
+++ b/source/LibMultiSense/details/legacy/channel.cc
@@ -384,8 +384,6 @@ Status LegacyChannel::set_configuration(const MultiSenseConfig &config)
 {
     using namespace crl::multisense::details;
 
-    std::lock_guard<std::mutex> lock(m_mutex);
-
     std::vector<Status> responses{};
 
     //
@@ -547,6 +545,8 @@ Status LegacyChannel::set_configuration(const MultiSenseConfig &config)
                                                     m_info.imu.has_value(),
                                                     ptp_enabled); new_config)
     {
+        std::lock_guard<std::mutex> lock(m_mutex);
+
         m_multisense_config = new_config.value();
 
         //

--- a/source/LibMultiSense/details/legacy/channel.cc
+++ b/source/LibMultiSense/details/legacy/channel.cc
@@ -389,6 +389,11 @@ Status LegacyChannel::set_configuration(const MultiSenseConfig &config)
     std::vector<Status> responses{};
 
     //
+    // For settings that impact camera hardware retry applying them
+    //
+    constexpr size_t setting_retries = 3;
+
+    //
     // Set the camera resolution
     //
     const auto res_ack = wait_for_ack(m_message_assembler,
@@ -396,7 +401,8 @@ Status LegacyChannel::set_configuration(const MultiSenseConfig &config)
                                       convert<wire::CamSetResolution>(config),
                                       m_transmit_id++,
                                       m_current_mtu,
-                                      m_config.receive_timeout);
+                                      m_config.receive_timeout,
+                                      setting_retries);
 
     if (!res_ack || res_ack->status != wire::Ack::Status_Ok)
     {
@@ -411,7 +417,8 @@ Status LegacyChannel::set_configuration(const MultiSenseConfig &config)
                                       convert<wire::CamControl>(config),
                                       m_transmit_id++,
                                       m_current_mtu,
-                                      m_config.receive_timeout);
+                                      m_config.receive_timeout,
+                                      setting_retries);
 
     if (!cam_ack || cam_ack->status != wire::Ack::Status_Ok)
     {
@@ -431,7 +438,8 @@ Status LegacyChannel::set_configuration(const MultiSenseConfig &config)
                                           convert(config.aux_config.value()),
                                           m_transmit_id++,
                                           m_current_mtu,
-                                          m_config.receive_timeout);
+                                          m_config.receive_timeout,
+                                          setting_retries);
         if (!aux_ack || aux_ack->status != wire::Ack::Status_Ok)
         {
             responses.push_back(get_status(aux_ack->status));
@@ -453,7 +461,8 @@ Status LegacyChannel::set_configuration(const MultiSenseConfig &config)
                                                   m_max_batched_imu_messages),
                                           m_transmit_id++,
                                           m_current_mtu,
-                                          m_config.receive_timeout);
+                                          m_config.receive_timeout,
+                                          setting_retries);
         if (!imu_ack || imu_ack->status != wire::Ack::Status_Ok)
         {
             responses.push_back(get_status(imu_ack->status));
@@ -473,7 +482,8 @@ Status LegacyChannel::set_configuration(const MultiSenseConfig &config)
                                                convert(config.lighting_config.value()),
                                                m_transmit_id++,
                                                m_current_mtu,
-                                               m_config.receive_timeout);
+                                               m_config.receive_timeout,
+                                               setting_retries);
         if (!lighting_ack || lighting_ack->status != wire::Ack::Status_Ok)
         {
             responses.push_back(get_status(lighting_ack->status));

--- a/source/LibMultiSense/details/legacy/configuration.cc
+++ b/source/LibMultiSense/details/legacy/configuration.cc
@@ -197,7 +197,7 @@ crl::multisense::details::wire::CamControl convert<crl::multisense::details::wir
     const auto auto_wb = config.image_config.auto_white_balance ? config.image_config.auto_white_balance.value() :
                                                                    MultiSenseConfig::AutoWhiteBalanceConfig{};
 
-    output.autoWhiteBalance = config.image_config.auto_white_balance_enabled;
+    output.autoWhiteBalance = config.image_config.auto_white_balance_enabled ? 1 : 0;
     output.autoWhiteBalanceDecay = auto_wb.decay;
     output.autoWhiteBalanceThresh  = auto_wb.threshold;
 
@@ -247,7 +247,7 @@ crl::multisense::details::wire::AuxCamControl convert(const MultiSenseConfig::Au
     const auto auto_wb = config.image_config.auto_white_balance ? config.image_config.auto_white_balance.value() :
                                                                   MultiSenseConfig::AutoWhiteBalanceConfig{};
 
-    output.autoWhiteBalance = config.image_config.auto_white_balance_enabled;
+    output.autoWhiteBalance = config.image_config.auto_white_balance_enabled ? 1 : 0;
     output.autoWhiteBalanceDecay = auto_wb.decay;
     output.autoWhiteBalanceThresh  = auto_wb.threshold;
 

--- a/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
@@ -745,7 +745,7 @@ struct MultiSenseConfig
 
         ///
         /// @brief The percentage strength of the sharpening gain to apply to the aux image
-        ///        Valid range is [0, 100]
+        ///        Valid range is [0, 100] with a step size of 100/255
         ///
         float sharpening_percentage = 50.0f;
 

--- a/source/LibMultiSense/include/details/legacy/utilities.hh
+++ b/source/LibMultiSense/include/details/legacy/utilities.hh
@@ -236,13 +236,10 @@ std::optional<OutputMessage> wait_for_data(MessageAssembler &assembler,
 
         if (auto ack = ack_waiter->wait<wire::Ack>(wait_time); ack)
         {
-            //
-            // TODO (malvarado): Uncomment this once the firmware issues are resolved
-            //
-            //if (ack->status != wire::Ack::Status_Ok)
-            //{
-            //    continue;
-            //}
+            if (ack->status != wire::Ack::Status_Ok)
+            {
+                continue;
+            }
 
             if (auto response = response_waiter->wait<OutputMessage>(wait_time); response)
             {
@@ -313,13 +310,10 @@ std::optional<TimedResponse<OutputMessage>> wait_for_data_timed(MessageAssembler
         {
             const auto end = std::chrono::high_resolution_clock::now();
 
-            //
-            // TODO (malvarado): Uncomment this once the firmware issues are resolved
-            //
-            //if (ack->status != wire::Ack::Status_Ok)
-            //{
-            //    continue;
-            //}
+            if (ack->status != wire::Ack::Status_Ok)
+            {
+                continue;
+            }
 
             if (auto response = response_waiter->wait<OutputMessage>(wait_time); response)
             {


### PR DESCRIPTION
- Retry operations which may take longer to complete since they require onboard HW reconfiguration
- Fix issue which prevented configs from being set while images were being streamed
- Re-enable ack validity checks