### PR TITLE
Invalidate the main image config white balance controls for new cams

### DIFF
--- a/python/bindings.cc
+++ b/python/bindings.cc
@@ -548,7 +548,8 @@ PYBIND11_MODULE(_libmultisense, m) {
         .def_readwrite("nominal_relative_aperture", &multisense::MultiSenseInfo::DeviceInfo::nominal_relative_aperture)
         .def_readwrite("lighting_type", &multisense::MultiSenseInfo::DeviceInfo::lighting_type)
         .def_readwrite("number_of_lights", &multisense::MultiSenseInfo::DeviceInfo::number_of_lights)
-        .def("has_aux_camera", &multisense::MultiSenseInfo::DeviceInfo::has_aux_camera);
+        .def("has_aux_camera", &multisense::MultiSenseInfo::DeviceInfo::has_aux_camera)
+        .def("has_main_stereo_color", &multisense::MultiSenseInfo::DeviceInfo::has_main_stereo_color);
 
     // MultiSenseInfo::Version
     py::class_<multisense::MultiSenseInfo::Version>(m, "Version")

--- a/source/LibMultiSense/details/legacy/configuration.cc
+++ b/source/LibMultiSense/details/legacy/configuration.cc
@@ -76,13 +76,15 @@ MultiSenseConfig convert(const crl::multisense::details::wire::CamConfig &config
     ms_config::AutoWhiteBalanceConfig auto_white_balance{config.autoWhiteBalanceDecay,
                                                                 config.autoWhiteBalanceThresh};
 
+    const bool main_color = info.has_main_stereo_color();
+
     ms_config::ImageConfig image{config.gamma,
-                                        (config.autoExposure != 0),
-                                        std::move(manual_exposure),
-                                        std::move(auto_exposure),
-                                        (config.autoWhiteBalance != 0),
-                                        std::move(manual_white_balance),
-                                        std::move(auto_white_balance)};
+                                 (config.autoExposure != 0),
+                                 std::move(manual_exposure),
+                                 std::move(auto_exposure),
+                                 (main_color && config.autoWhiteBalance != 0),
+                                 (main_color ? std::make_optional(std::move(manual_white_balance)) : std::nullopt),
+                                 (main_color ? std::make_optional(std::move(auto_white_balance)) : std::nullopt)};
 
     return MultiSenseConfig{config.width,
                             config.height,
@@ -189,13 +191,13 @@ crl::multisense::details::wire::CamControl convert<crl::multisense::details::wir
 
 
     const auto manual_wb = config.image_config.manual_white_balance ? config.image_config.manual_white_balance.value() :
-                                                                   MultiSenseConfig::ManualWhiteBalanceConfig{};
+                                                                      MultiSenseConfig::ManualWhiteBalanceConfig{};
 
     output.whiteBalanceRed = manual_wb.red;
     output.whiteBalanceBlue = manual_wb.blue;
 
     const auto auto_wb = config.image_config.auto_white_balance ? config.image_config.auto_white_balance.value() :
-                                                                   MultiSenseConfig::AutoWhiteBalanceConfig{};
+                                                                  MultiSenseConfig::AutoWhiteBalanceConfig{};
 
     output.autoWhiteBalance = config.image_config.auto_white_balance_enabled ? 1 : 0;
     output.autoWhiteBalanceDecay = auto_wb.decay;

--- a/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
@@ -1468,7 +1468,7 @@ struct MultiSenseInfo
         uint32_t number_of_lights = 0;
 
         ///
-        /// @brief Determine if the MultiSense has a Aux color camera based on the DeviceInfo
+        /// @brief Determine if the MultiSense has a Aux color camera
         ///
         constexpr bool has_aux_camera() const
         {
@@ -1476,8 +1476,23 @@ struct MultiSenseInfo
             {
                 case HardwareRevision::S27:
                 case HardwareRevision::S30:
-                case HardwareRevision::MONOCAM:
                 case HardwareRevision::KS21i:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        ///
+        /// @brief Determine if the MultiSense's main stereo pair supports color
+        ///
+        constexpr bool has_main_stereo_color() const
+        {
+            switch (hardware_revision)
+            {
+                case HardwareRevision::S7:
+                case HardwareRevision::S21:
+                case HardwareRevision::MONOCAM:
                     return true;
                 default:
                     return false;

--- a/source/LibMultiSense/test/configuration_test.cc
+++ b/source/LibMultiSense/test/configuration_test.cc
@@ -93,6 +93,8 @@ multisense::MultiSenseInfo::DeviceInfo create_device_info(uint32_t imager_width,
     info.imager_width = imager_width;
     info.imager_height = imager_height;
 
+    info.hardware_revision = multisense::MultiSenseInfo::DeviceInfo::HardwareRevision::S7;
+
     info.lighting_type = multisense::MultiSenseInfo::DeviceInfo::LightingType::EXTERNAL;
 
     return info;
@@ -280,14 +282,18 @@ void check_equal(const ConfigT &config,
     ASSERT_EQ(config.auto_exposure->roi.width, control.autoExposureRoiWidth);
     ASSERT_EQ(config.auto_exposure->roi.height, control.autoExposureRoiHeight);
 
-    ASSERT_TRUE(static_cast<bool>(config.manual_white_balance));
-    ASSERT_FLOAT_EQ(config.manual_white_balance->red, control.whiteBalanceRed);
-    ASSERT_FLOAT_EQ(config.manual_white_balance->blue, control.whiteBalanceBlue);
+    if (config.manual_white_balance)
+    {
+        ASSERT_FLOAT_EQ(config.manual_white_balance->red, control.whiteBalanceRed);
+        ASSERT_FLOAT_EQ(config.manual_white_balance->blue, control.whiteBalanceBlue);
+    }
 
-    ASSERT_TRUE(static_cast<bool>(config.auto_white_balance));
-    ASSERT_EQ(config.auto_white_balance_enabled, control.autoWhiteBalance);
-    ASSERT_EQ(config.auto_white_balance->decay, control.autoWhiteBalanceDecay);
-    ASSERT_EQ(config.auto_white_balance->threshold, control.autoWhiteBalanceThresh);
+    if (config.auto_white_balance)
+    {
+        ASSERT_EQ(config.auto_white_balance_enabled, control.autoWhiteBalance);
+        ASSERT_EQ(config.auto_white_balance->decay, control.autoWhiteBalanceDecay);
+        ASSERT_EQ(config.auto_white_balance->threshold, control.autoWhiteBalanceThresh);
+    }
 
     ASSERT_EQ(config.gamma, control.gamma);
 }


### PR DESCRIPTION
To limit confusion, disable white balance controls for the main stereo pair if we are using the current HW gen of the MultiSense