### PR TITLE
Fix CI builds by using a venv for Ubuntu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtest-dev nlohmann-json3-dev pybind11-dev python3-pip ninja-build
-          pip install --upgrade scikit-build-core
-          pip install --upgrade packaging
+          pip install --force-reinstall -v "scikit-build-core=0.10"
 
       - name: Build Release
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           mkdir pip-wheel
           python -m venv .venv
           source .venv/bin/activate
-          pip wheel -vv --wheel-dir pip-wheel .
+          pip wheel --wheel-dir pip-wheel .
 
       - name: Upload Release Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtest-dev nlohmann-json3-dev pybind11-dev python3-pip ninja-build
-          pip install --force-reinstall -v "scikit-build-core=0.10"
+          pip install --force-reinstall -v "scikit-build-core==0.10"
 
       - name: Build Release
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,8 @@ jobs:
           make -C build test
           cmake --install build
           mkdir pip-wheel
-          python -m venv python_build
-          python_build/bin/activate
+          python -m venv .venv
+          source .venv/bin/activate
           pip wheel -vv --wheel-dir pip-wheel .
 
       - name: Upload Release Artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           make -C build test
           cmake --install build
           mkdir pip-wheel
-          pip wheel --wheel-dir pip-wheel .
+          pip wheel -vv --wheel-dir pip-wheel .
 
       - name: Upload Release Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,8 @@ jobs:
           make -C build test
           cmake --install build
           mkdir pip-wheel
+          python -m venv python_build
+          python_build/bin/activate
           pip wheel -vv --wheel-dir pip-wheel .
 
       - name: Upload Release Artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtest-dev nlohmann-json3-dev pybind11-dev python3-pip ninja-build
           pip install --upgrade scikit-build-core
+          pip install --upgrade packaging
 
       - name: Build Release
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtest-dev nlohmann-json3-dev pybind11-dev python3-pip ninja-build
+          pip install --upgrade scikit-build-core
 
       - name: Build Release
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtest-dev nlohmann-json3-dev pybind11-dev python3-pip ninja-build
-          pip install --force-reinstall -v "scikit-build-core==0.10"
 
       - name: Build Release
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.10", "pybind11", "packaging<24"]
+requires = ["scikit-build-core>=0.10", "pybind11"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.10", "pybind11"]
+requires = ["scikit-build-core>=0.10", "pybind11", "packaging>=24.2"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.10", "pybind11", "packaging>=24.2"]
+requires = ["scikit-build-core>=0.11.1", "pybind11", "packaging>=24.2"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.10", "pybind11"]
+requires = ["scikit-build-core>=0.10", "pybind11", "packaging<24"]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
The 22.04 CI builds system python packages seem to be incompatible with the required scikit-build versions