### PR TITLE
Use cibuildwheel to generate pypi releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtest-dev nlohmann-json3-dev pybind11-dev python3-pip ninja-build
+          sudo apt-get update
 
       - name: Build Release
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtest-dev nlohmann-json3-dev pybind11-dev python3-pip ninja-build
-          sudo apt-get update
 
       - name: Build Release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
           output-dir: wheelhouse
         env:
           CIBW_SKIP: "pp* *-musllinux*"
+          CIBW_ARCHS_MACOS: universal2
           CIBW_BEFORE_ALL_LINUX: >
             pip install pybind11 &&
             git clone https://github.com/nlohmann/json.git &&
@@ -85,7 +86,7 @@ jobs:
             ./vcpkg/vcpkg install pybind11 nlohmann-json --triplet x64-windows &&
             set PATH=%PATH%;%cd%\vcpkg\installed\x64-windows\bin &&
             pip install pybind11
-          CIBW_ENVIRONMENT_WINDOWS: "PATH=%PATH%;${{ github.workspace }}\\vcpkg\\installed\\x64-windows\\bin"
+          CIBW_ENVIRONMENT_WINDOWS: PATH="$PATH;${{ github.workspace }}/vcpkg/installed/x64-windows/bin"
           CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=10.15"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,16 +65,22 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.18.1
+        with:
+          output-dir: wheelhouse
         env:
           CIBW_SKIP: "pp* *-musllinux*"
           CIBW_BEFORE_ALL_LINUX: >
-            yum install -y nlohmann-json3-dev pybind11-dev python3-pip ninja-build
+            yum install -y epel-release cmake3 ninja-build nlohmann-json-devel &&
+            pip install pybind11
           CIBW_BEFORE_ALL_MACOS: >
             brew install cmake ninja nlohmann-json pybind11
           CIBW_BEFORE_ALL_WINDOWS: >
-            git clone https://github.com/microsoft/vcpkg.git
-            ./vcpkg/bootstrap-vcpkg.bat
-            ./vcpkg/vcpkg install --triplet x64-windows
+            choco install cmake ninja &&
+            git clone https://github.com/microsoft/vcpkg.git &&
+            ./vcpkg/bootstrap-vcpkg.bat &&
+            ./vcpkg/vcpkg install pybind11 nlohmann-json --triplet x64-windows &&
+            set PATH=%PATH%;%cd%\vcpkg\installed\x64-windows\bin &&
+            pip install pybind11
           CIBW_ENVIRONMENT_WINDOWS: "PATH=$PATH;${{ github.workspace }}/vcpkg/installed/x64-windows/bin"
           CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=10.15"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
@@ -89,7 +95,7 @@ jobs:
         with:
           files: |
             libmultisense-${{ matrix.os }}.zip
-            dist/*.whl
+            wheelhouse/*.whl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
         env:
           CIBW_SKIP: "pp* *-musllinux*"
           CIBW_BEFORE_BUILD: >
-            pip install cmake ninja &&
+            pip install cmake ninja pybind11 nlohmann-json &&
             cmake -B build -S . \
               -DBUILD_JSON_SERIALIZATION=ON \
               -DBUILD_PYTHON_BINDINGS=ON \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,7 @@ jobs:
     env:
         VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
 
+    steps:
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,6 @@ jobs:
           output-dir: wheelhouse
         env:
           CIBW_SKIP: "pp* *-musllinux*"
-          CIBW_ARCHS_MACOS: universal2
           CIBW_BEFORE_ALL_LINUX: >
             pip install pybind11 &&
             git clone https://github.com/nlohmann/json.git &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,6 @@ jobs:
 
           cmake --build build --config Release --target install -j "$(nproc || sysctl -n hw.ncpu || echo 8)"
           rm -rf build
-          mkdir pip-wheel
-          pip wheel --wheel-dir pip-wheel .
-          python3 -m build
 
       - name: Zip binaries (Windows)
         if: matrix.os == 'windows-2022'
@@ -79,13 +76,33 @@ jobs:
           zip -r ../libmultisense-${{ matrix.os }}_python_dist.zip .
           cd ..
 
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.18.1
+        env:
+          CIBW_SKIP: "pp* *-musllinux*"
+          CIBW_BEFORE_BUILD: >
+            pip install cmake ninja &&
+            cmake -B build -S .
+              -DBUILD_JSON_SERIALIZATION=ON
+              -DBUILD_PYTHON_BINDINGS=ON
+              -DBUILD_LEGACY_API=OFF
+              -DCMAKE_BUILD_TYPE=Release &&
+            cmake --build build --target install -j "$(nproc || sysctl -n hw.ncpu || echo 8)"
+          CIBW_ENVIRONMENT_WINDOWS: "PATH=$PATH;${{ github.workspace }}/vcpkg/installed/x64-windows/bin"
+          CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=10.15"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel-artifacts-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
+
       - name: Upload binaries to Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
             libmultisense-${{ matrix.os }}.zip
-            libmultisense-${{ matrix.os }}_python_dist.zip
-            pip-wheel/*.whl
+            dist/*.whl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,9 +103,9 @@ jobs:
             brew install cmake ninja nlohmann-json pybind11
           CIBW_BEFORE_ALL_WINDOWS: >
             choco install cmake ninja &&
-            git clone https://github.com/microsoft/vcpkg.git
-            ./vcpkg/bootstrap-vcpkg.bat
-            ./vcpkg/vcpkg install --triplet x64-windows
+            git clone https://github.com/microsoft/vcpkg.git &&
+            ./vcpkg/bootstrap-vcpkg.bat &&
+            ./vcpkg/vcpkg install --triplet x64-windows &&
             set PATH=%PATH%;%cd%\vcpkg\installed\x64-windows\bin &&
             pip install pybind11
           CIBW_ENVIRONMENT_WINDOWS: PATH="$PATH;${{ github.workspace }}/vcpkg/installed/x64-windows/bin"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
             pip install pybind11 &&
             git clone https://github.com/nlohmann/json.git &&
             cd json &&
-            cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/usr &&
+            cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/usr -DJSON_BuildTests=OFF &&
             cmake --build build --target install &&
             cmake --install build
           CIBW_BEFORE_ALL_MACOS: >

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.18.1
+        uses: pypa/cibuildwheel@v2.23.2
         with:
           output-dir: wheelhouse
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,15 +23,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y nlohmann-json3-dev pybind11-dev python3-pip ninja-build
-          pip install build
 
       - name: Install Dependencies (macOS)
         if: matrix.os == 'macos-latest'
         run: |
           brew install pybind11 nlohmann-json
-          python3 -m venv venv
-          source venv/bin/activate
-          pip install build wheel
 
       - name: Install Dependencies (Windows)
         if: matrix.os == 'windows-2022'
@@ -39,15 +35,10 @@ jobs:
           git clone https://github.com/microsoft/vcpkg.git
           ./vcpkg/bootstrap-vcpkg.bat
           ./vcpkg/vcpkg install --triplet x64-windows
-          pip install build
 
       - name: Build Release
         shell: bash
         run: |
-          if [ "${{ matrix.os }}" = "macos-latest" ]; then
-            source venv/bin/activate
-          fi
-
           cmake -B build -S . \
             -DBUILD_JSON_SERIALIZATION=ON \
             -DBUILD_PYTHON_BINDINGS=ON \
@@ -76,8 +67,15 @@ jobs:
         uses: pypa/cibuildwheel@v2.18.1
         env:
           CIBW_SKIP: "pp* *-musllinux*"
+          CIBW_BEFORE_ALL_LINUX: >
+            apt-get install -y nlohmann-json3-dev pybind11-dev python3-pip ninja-build
+          CIBW_BEFORE_ALL_MACOS: >
+            brew install cmake ninja nlohmann-json pybind11
+          CIBW_BEFORE_ALL_WINDOWS: >
+            git clone https://github.com/microsoft/vcpkg.git
+            ./vcpkg/bootstrap-vcpkg.bat
+            ./vcpkg/vcpkg install --triplet x64-windows
           CIBW_BEFORE_BUILD: >
-            pip install cmake ninja pybind11 nlohmann-json &&
             cmake -B build -S . \
               -DBUILD_JSON_SERIALIZATION=ON \
               -DBUILD_PYTHON_BINDINGS=ON \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,13 +70,12 @@ jobs:
         env:
           CIBW_SKIP: "pp* *-musllinux*"
           CIBW_BEFORE_ALL_LINUX: >
-            yum install -y epel-release &&
-            yum install -y cmake3 ninja-build &&
             pip install pybind11 &&
             git clone https://github.com/nlohmann/json.git &&
             cd json &&
-            cmake3 -S . -B build -DCMAKE_INSTALL_PREFIX=/usr &&
-            cmake3 --build build --target install
+            cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/usr &&
+            cmake --build build --target install &&
+            cmake --install build
           CIBW_BEFORE_ALL_MACOS: >
             brew install cmake ninja nlohmann-json pybind11
           CIBW_BEFORE_ALL_WINDOWS: >
@@ -103,7 +102,6 @@ jobs:
           cd wheelhouse
           zip -r ../libmultisense-${{ matrix.os }}-wheels.zip .
           cd ..
-
 
       - name: Upload binaries to Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,13 @@ jobs:
         env:
           CIBW_SKIP: "pp* *-musllinux*"
           CIBW_BEFORE_ALL_LINUX: >
-            yum install -y epel-release cmake3 ninja-build nlohmann-json-devel &&
-            pip install pybind11
+            yum install -y epel-release &&
+            yum install -y cmake3 ninja-build &&
+            pip install pybind11 &&
+            git clone https://github.com/nlohmann/json.git &&
+            cd json &&
+            cmake3 -S . -B build -DCMAKE_INSTALL_PREFIX=/usr &&
+            cmake3 --build build --target install
           CIBW_BEFORE_ALL_MACOS: >
             brew install cmake ninja nlohmann-json pybind11
           CIBW_BEFORE_ALL_WINDOWS: >
@@ -81,21 +86,31 @@ jobs:
             ./vcpkg/vcpkg install pybind11 nlohmann-json --triplet x64-windows &&
             set PATH=%PATH%;%cd%\vcpkg\installed\x64-windows\bin &&
             pip install pybind11
-          CIBW_ENVIRONMENT_WINDOWS: "PATH=$PATH;${{ github.workspace }}/vcpkg/installed/x64-windows/bin"
+          CIBW_ENVIRONMENT_WINDOWS: "PATH=%PATH%;${{ github.workspace }}\\vcpkg\\installed\\x64-windows\\bin"
           CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=10.15"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: wheel-artifacts-${{ matrix.os }}
-          path: ./wheelhouse/*.whl
+      - name: Zip wheels (Windows)
+        if: matrix.os == 'windows-2022'
+        shell: pwsh
+        run: |
+          Compress-Archive -Path wheelhouse/* -DestinationPath libmultisense-windows-2022-wheels.zip
+
+      - name: Zip wheels (Linux/macOS)
+        if: matrix.os != 'windows-2022'
+        shell: bash
+        run: |
+          cd wheelhouse
+          zip -r ../libmultisense-${{ matrix.os }}-wheels.zip .
+          cd ..
+
 
       - name: Upload binaries to Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
             libmultisense-${{ matrix.os }}.zip
-            wheelhouse/*.whl
+            libmultisense-${{ matrix.os }}-wheels.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         env:
           CIBW_SKIP: "pp* *-musllinux*"
           CIBW_BEFORE_ALL_LINUX: >
-            apt-get install -y nlohmann-json3-dev pybind11-dev python3-pip ninja-build
+            yum install -y nlohmann-json3-dev pybind11-dev python3-pip ninja-build
           CIBW_BEFORE_ALL_MACOS: >
             brew install cmake ninja nlohmann-json pybind11
           CIBW_BEFORE_ALL_WINDOWS: >
@@ -81,7 +81,7 @@ jobs:
               -DBUILD_PYTHON_BINDINGS=ON \
               -DBUILD_LEGACY_API=OFF \
               -DCMAKE_BUILD_TYPE=Release &&
-            cmake --build build --target install -j "$(nproc || sysctl -n hw.ncpu || echo 8)"
+            cmake --build build -j "$(nproc || sysctl -n hw.ncpu || echo 8)"
           CIBW_ENVIRONMENT_WINDOWS: "PATH=$PATH;${{ github.workspace }}/vcpkg/installed/x64-windows/bin"
           CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=10.15"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,6 @@ jobs:
         shell: pwsh
         run: |
           Compress-Archive -Path install-release/* -DestinationPath libmultisense-windows-2022.zip
-          Compress-Archive -Path dist/* -DestinationPath libmultisense-windows-2022_python_dist.zip
 
       - name: Zip binaries (Linux/macOS)
         if: matrix.os != 'windows-2022'
@@ -71,9 +70,6 @@ jobs:
         run: |
           cd install-release
           zip -r ../libmultisense-${{ matrix.os }}.zip .
-          cd ..
-          cd dist
-          zip -r ../libmultisense-${{ matrix.os }}_python_dist.zip .
           cd ..
 
       - name: Build wheels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,27 @@ jobs:
           zip -r ../libmultisense-${{ matrix.os }}.zip .
           cd ..
 
+      - name: Upload binaries to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            libmultisense-${{ matrix.os }}.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+  build-wheels:
+    strategy:
+      matrix:
+        os: [ubuntu-24.04, macos-latest, windows-2022]
+
+    runs-on: ${{ matrix.os }}
+    env:
+        VCPKG_ROOT: "${{ github.workspace }}/vcpkg"
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.18.1
         with:
@@ -81,10 +102,9 @@ jobs:
             brew install cmake ninja nlohmann-json pybind11
           CIBW_BEFORE_ALL_WINDOWS: >
             choco install cmake ninja &&
-            rm -rf vcpkg &&
-            git clone https://github.com/microsoft/vcpkg.git &&
-            ./vcpkg/bootstrap-vcpkg.bat &&
-            ./vcpkg/vcpkg install pybind11 nlohmann-json --triplet x64-windows &&
+            git clone https://github.com/microsoft/vcpkg.git
+            ./vcpkg/bootstrap-vcpkg.bat
+            ./vcpkg/vcpkg install --triplet x64-windows
             set PATH=%PATH%;%cd%\vcpkg\installed\x64-windows\bin &&
             pip install pybind11
           CIBW_ENVIRONMENT_WINDOWS: PATH="$PATH;${{ github.workspace }}/vcpkg/installed/x64-windows/bin"
@@ -105,11 +125,10 @@ jobs:
           zip -r ../libmultisense-${{ matrix.os }}-wheels.zip .
           cd ..
 
-      - name: Upload binaries to Release
+      - name: Upload wheels to Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            libmultisense-${{ matrix.os }}.zip
             libmultisense-${{ matrix.os }}-wheels.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,13 +75,6 @@ jobs:
             git clone https://github.com/microsoft/vcpkg.git
             ./vcpkg/bootstrap-vcpkg.bat
             ./vcpkg/vcpkg install --triplet x64-windows
-          CIBW_BEFORE_BUILD: >
-            cmake -B build -S . \
-              -DBUILD_JSON_SERIALIZATION=ON \
-              -DBUILD_PYTHON_BINDINGS=ON \
-              -DBUILD_LEGACY_API=OFF \
-              -DCMAKE_BUILD_TYPE=Release &&
-            cmake --build build -j "$(nproc || sysctl -n hw.ncpu || echo 8)"
           CIBW_ENVIRONMENT_WINDOWS: "PATH=$PATH;${{ github.workspace }}/vcpkg/installed/x64-windows/bin"
           CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=10.15"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,10 +78,10 @@ jobs:
           CIBW_SKIP: "pp* *-musllinux*"
           CIBW_BEFORE_BUILD: >
             pip install cmake ninja &&
-            cmake -B build -S .
-              -DBUILD_JSON_SERIALIZATION=ON
-              -DBUILD_PYTHON_BINDINGS=ON
-              -DBUILD_LEGACY_API=OFF
+            cmake -B build -S . \
+              -DBUILD_JSON_SERIALIZATION=ON \
+              -DBUILD_PYTHON_BINDINGS=ON \
+              -DBUILD_LEGACY_API=OFF \
               -DCMAKE_BUILD_TYPE=Release &&
             cmake --build build --target install -j "$(nproc || sysctl -n hw.ncpu || echo 8)"
           CIBW_ENVIRONMENT_WINDOWS: "PATH=$PATH;${{ github.workspace }}/vcpkg/installed/x64-windows/bin"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,8 +104,8 @@ jobs:
           CIBW_BEFORE_ALL_WINDOWS: >
             choco install cmake ninja &&
             git clone https://github.com/microsoft/vcpkg.git &&
-            ./vcpkg/bootstrap-vcpkg.bat &&
-            ./vcpkg/vcpkg install --triplet x64-windows &&
+            vcpkg\bootstrap-vcpkg.bat &&
+            vcpkg\vcpkg install --triplet x64-windows &&
             set PATH=%PATH%;%cd%\vcpkg\installed\x64-windows\bin &&
             pip install pybind11
           CIBW_ENVIRONMENT_WINDOWS: PATH="$PATH;${{ github.workspace }}/vcpkg/installed/x64-windows/bin"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,7 @@ jobs:
             pip install pybind11 &&
             git clone https://github.com/nlohmann/json.git &&
             cd json &&
+            git checkout v3.11.3 &&
             cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/usr -DJSON_BuildTests=OFF &&
             cmake --build build --target install &&
             cmake --install build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,7 @@ jobs:
             brew install cmake ninja nlohmann-json pybind11
           CIBW_BEFORE_ALL_WINDOWS: >
             choco install cmake ninja &&
+            rm -rf vcpkg &&
             git clone https://github.com/microsoft/vcpkg.git &&
             ./vcpkg/bootstrap-vcpkg.bat &&
             ./vcpkg/vcpkg install pybind11 nlohmann-json --triplet x64-windows &&

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ This will require a system installation of pybind11, or an installation which ca
 
 ### googletest
 
-LibMultiSense optionally uses googletest for unit testing the C+ API. To build the googletest unit tests
+LibMultiSense optionally uses googletest for unit testing the C++ API. To build the googletest unit tests
 the following CMake argument should be set
 
     -DBUILD_TESTS=ON

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,7 @@ authors = [
 ]
 
 requires-python = ">=3.8"
-
-license = "BSD-3-Clause"
-license-files = ["LICENSE.TXT"]
+license = {text = "BSD-3-Clause"}
 
 [tool.scikit-build.cmake]
 args = ["-DBUILD_PYTHON_BINDINGS=ON", "-DBUILD_JSON_SERIALIZATION=ON", "-DBUILD_SHARED_LIBS=OFF", "-DBUILD_LEGACY_API=OFF"]
@@ -22,3 +20,7 @@ args = ["-DBUILD_PYTHON_BINDINGS=ON", "-DBUILD_JSON_SERIALIZATION=ON", "-DBUILD_
 [project.urls]
 Homepage = "https://github.com/carnegierobotics/libmultisense"
 Issues = "https://github.com/carnegierobotics/libmultisense/issues"
+
+[tool.scikit-build]
+license-files = ["LICENSE.TXT"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ authors = [
 ]
 
 requires-python = ">=3.8"
-license = {text = "BSD-3-Clause"}
 
 [tool.scikit-build.cmake]
 args = ["-DBUILD_PYTHON_BINDINGS=ON", "-DBUILD_JSON_SERIALIZATION=ON", "-DBUILD_SHARED_LIBS=OFF", "-DBUILD_LEGACY_API=OFF"]
@@ -20,7 +19,3 @@ args = ["-DBUILD_PYTHON_BINDINGS=ON", "-DBUILD_JSON_SERIALIZATION=ON", "-DBUILD_
 [project.urls]
 Homepage = "https://github.com/carnegierobotics/libmultisense"
 Issues = "https://github.com/carnegierobotics/libmultisense/issues"
-
-[tool.scikit-build]
-license-files = ["LICENSE.TXT"]
-

--- a/source/LibMultiSense/include/details/legacy/message.hh
+++ b/source/LibMultiSense/include/details/legacy/message.hh
@@ -350,7 +350,7 @@ private:
     ///
     /// @brief A counter for the number of messages we have received
     ///
-    std::atomic_uint64_t m_received_messages = 0;
+    std::atomic_size_t m_received_messages = 0;
 
     ///
     /// @brief The a flag which indicates if a message is being processed
@@ -360,12 +360,12 @@ private:
     ///
     /// @brief A counter for the number of messages we dispatched
     ///
-    std::atomic_uint64_t m_dispatched_messages = 0;
+    std::atomic_size_t m_dispatched_messages = 0;
 
     ///
     /// @brief A counter for the number of invalid packets we received
     ///
-    std::atomic_uint64_t m_invalid_packets = 0;
+    std::atomic_size_t m_invalid_packets = 0;
 };
 
 }


### PR DESCRIPTION
Use the cibuildwheel action to generate wheels for linux, macos, and windows