### PR TITLE
Restrict netconfig

### DIFF
--- a/source/Legacy/details/public.cc
+++ b/source/Legacy/details/public.cc
@@ -1564,6 +1564,11 @@ Status impl::getMotorPos(int32_t& pos)
 
 Status impl::setNetworkConfig(const system::NetworkConfig& c)
 {
+    if (c.ipv4Address == "0.0.0.0" || c.ipv4Address == "255.255.255.255" ||
+        c.ipv4Gateway == "0.0.0.0" || c.ipv4Gateway == "255.255.255.255" ||
+        c.ipv4Netmask == "0.0.0.0" || c.ipv4Netmask == "255.255.255.255")
+        return Status_Unsupported;
+
     return waitAck(wire::SysNetwork(c.ipv4Address,
                                     c.ipv4Gateway,
                                     c.ipv4Netmask));

--- a/source/LibMultiSense/details/legacy/channel.cc
+++ b/source/LibMultiSense/details/legacy/channel.cc
@@ -702,6 +702,11 @@ Status LegacyChannel::set_network_config(const MultiSenseInfo::NetworkInfo &conf
 {
     using namespace crl::multisense::details;
 
+    if (config.ip_address == "0.0.0.0" || config.ip_address == "255.255.255.255" ||
+        config.gateway == "0.0.0.0"    || config.gateway == "255.255.255.255"    ||
+        config.netmask == "0.0.0.0"    || config.netmask == "255.255.255.255")
+        return Status::UNSUPPORTED;
+
     if (const auto ack = wait_for_ack(m_message_assembler,
                                       m_socket,
                                       convert(config),

--- a/source/Utilities/portability/CalibrationYaml.hh
+++ b/source/Utilities/portability/CalibrationYaml.hh
@@ -37,6 +37,7 @@
 
 #include <stdint.h>
 #include <iostream>
+#include <iomanip>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Restrict some easy to identify invalid netconfigs 
Fix build with legacy API enabled