### PR TITLE
Don't stamp images/imu data with 0ns ptp times

### DIFF
--- a/source/Legacy/details/dispatch.cc
+++ b/source/Legacy/details/dispatch.cc
@@ -462,8 +462,9 @@ void impl::dispatch(utility::BufferStreamWriter& buffer)
             imu::Sample&           a = header.samples[i];
 
             //
-            // PTP timestamps which are 0ns are invalid and indicate PTP has lost it's sync. If that
-            // is the case, don't want to just pass that timestamp on
+            // PTP timestamps which are 0ns are invalid and indicate the camera has lost its PTP sync with the PTP master.
+            // If that is the case, prefer to stamp the data with the non-PTP time sources
+
             if (m_ptpTimeSyncEnabled && w.ptpNanoSeconds != 0)
             {
                 toHeaderTime(w.ptpNanoSeconds, a.timeSeconds, a.timeMicroSeconds);

--- a/source/Legacy/details/dispatch.cc
+++ b/source/Legacy/details/dispatch.cc
@@ -461,7 +461,10 @@ void impl::dispatch(utility::BufferStreamWriter& buffer)
             const wire::ImuSample& w = imu.samples[i];
             imu::Sample&           a = header.samples[i];
 
-            if (m_ptpTimeSyncEnabled)
+            //
+            // PTP timestamps which are 0ns are invalid and indicate PTP has lost it's sync. If that
+            // is the case, don't want to just pass that timestamp on
+            if (m_ptpTimeSyncEnabled && w.ptpNanoSeconds != 0)
             {
                 toHeaderTime(w.ptpNanoSeconds, a.timeSeconds, a.timeMicroSeconds);
             }

--- a/source/Legacy/include/MultiSense/details/channel.hh
+++ b/source/Legacy/include/MultiSense/details/channel.hh
@@ -256,8 +256,8 @@ private:
                 uint32_t &microSeconds)
     {
         //
-        // PTP timestamps which are 0ns are invalid and indicate PTP has lost it's sync. If that
-        // is the case, don't want to just pass that timestamp on
+        // PTP timestamps which are 0ns are invalid and indicate the camera has lost its PTP sync with the PTP master.
+        // If that is the case, prefer to stamp the data with the non-PTP time sources
 
         if (m_ptpTimeSyncEnabled && wire->ptpNanoSeconds != 0) {
 

--- a/source/Legacy/include/MultiSense/details/channel.hh
+++ b/source/Legacy/include/MultiSense/details/channel.hh
@@ -255,7 +255,11 @@ private:
                 uint32_t &seconds,
                 uint32_t &microSeconds)
     {
-        if (m_ptpTimeSyncEnabled) {
+        //
+        // PTP timestamps which are 0ns are invalid and indicate PTP has lost it's sync. If that
+        // is the case, don't want to just pass that timestamp on
+
+        if (m_ptpTimeSyncEnabled && wire->ptpNanoSeconds != 0) {
 
             toHeaderTime(wire->ptpNanoSeconds, seconds, microSeconds);
 


### PR DESCRIPTION
If our PTP sync is invalid, either use the network time sync or the camera timestamp to stamp images and IMU data. This eliminates the case where data will be stamps with 0ns times. 