### PR TITLE
Handle the case where both the internal and external configs are invalid

### DIFF
--- a/source/LibMultiSense/details/legacy/channel.cc
+++ b/source/LibMultiSense/details/legacy/channel.cc
@@ -490,7 +490,7 @@ Status LegacyChannel::set_config(const MultiSenseConfig &config)
     //
     // Set lighting controls if they are valid
     //
-    if (config.lighting_config)
+    if (config.lighting_config && (config.lighting_config->internal || config.lighting_config->external))
     {
         //
         // Set the lighting controls


### PR DESCRIPTION
Handle exceptions when both the internal and external LED configs are invalid