### PR TITLE
Suggest users use v7.22 firmware

### DIFF
--- a/source/LibMultiSense/details/legacy/channel.cc
+++ b/source/LibMultiSense/details/legacy/channel.cc
@@ -320,6 +320,20 @@ Status LegacyChannel::connect(const Config &config)
     }
 
     //
+    // If we are running a new version of MultiSense hardware, make sure we are running at least
+    // v7.22 firmware for the best compatibility with this API
+    //
+    if ((m_info.device.hardware_revision == MultiSenseInfo::DeviceInfo::HardwareRevision::S27 ||
+         m_info.device.hardware_revision == MultiSenseInfo::DeviceInfo::HardwareRevision::S30 ||
+         m_info.device.hardware_revision == MultiSenseInfo::DeviceInfo::HardwareRevision::KS21) &&
+         m_info.version.firmware_version < MultiSenseInfo::Version{7, 22, 0})
+    {
+        CRL_DEBUG("WARNING: Please upgrade the MultiSense firmware to the most recent firmware release "
+                  "for the best performance. See https://docs.carnegierobotics.com/firmware/update.html "
+                  "for update instructions and general firmware information");
+    }
+
+    //
     // Update our cached multisense configuration
     //
     if (auto cam_config = query_configuration(m_info.device.has_aux_camera(), m_info.imu.has_value(), false); cam_config)

--- a/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
@@ -44,6 +44,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #ifdef HAVE_OPENCV
@@ -1530,13 +1531,43 @@ struct MultiSenseInfo
         }
 
         ///
-        /// @brief Convenience operator for comparing versions
+        /// @brief Convenience equality operator for comparing versions
+        ///
+        bool operator==(const Version& other) const
+        {
+            return std::tie(major, minor, patch) == std::tie(other.major, other.minor, other.patch);
+        }
+
+        ///
+        /// @brief Convenience less-than operator for comparing versions
         ///
         bool operator<(const Version& other) const
         {
-            return major < other.major ||
-                   (major == other.major && minor < other.minor) ||
-                   (major == other.major && minor == other.minor && patch < other.patch);
+            return std::tie(major, minor, patch) < std::tie(other.major, other.minor, other.patch);
+        }
+
+        ///
+        /// @brief Convenience less-than or equal to operator for comparing versions
+        ///
+        bool operator<=(const Version& other) const
+        {
+            return *this < other || *this == other;
+        }
+
+        ///
+        /// @brief Convenience greater-than operator for comparing versions
+        ///
+        bool operator>(const Version& other) const
+        {
+            return other < *this;
+        }
+
+        ///
+        /// @brief Convenience greater-than or equal to operator for comparing versions
+        ///
+        bool operator>=(const Version& other) const
+        {
+            return other <= *this;
         }
     };
 


### PR DESCRIPTION
Try and get users to update the firmware on their cameras with a warning message. Older firmware may not work well with the new API with regards to status reporting