### PR TITLE
Invert the connect on startup logic when specifying an interface

### DIFF
--- a/source/Utilities/LibMultiSense/ChangeIpUtility/ChangeIpUtility.cc
+++ b/source/Utilities/LibMultiSense/ChangeIpUtility/ChangeIpUtility.cc
@@ -104,7 +104,7 @@ int main(int argc, char** argv)
     }
 
     lms::Channel::Config config{ip_address};
-    config.connect_on_initialization = static_cast<bool>(interface);
+    config.connect_on_initialization = !static_cast<bool>(interface);
     const auto channel = lms::Channel::create(config);
 
     if (!channel)


### PR DESCRIPTION
Make sure we connect on startup when we don't specify a broadcast interface