### PR TITLE
Remove the retired Ubuntu 20.04 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   build-ubuntu:
     strategy:
       matrix:
-        ubuntu: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        ubuntu: [ubuntu-22.04, ubuntu-24.04]
     runs-on: ${{ matrix.ubuntu }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
The Ubuntu 20.04 runner is retired as of 2025-04-15.  See https://github.com/actions/runner-images/issues/11101.

Resolves #227.