### PR TITLE
rename powerSupply/power_supply temperature to CPU temperature

### DIFF
--- a/python/bindings.cc
+++ b/python/bindings.cc
@@ -456,10 +456,10 @@ PYBIND11_MODULE(_libmultisense, m) {
     py::class_<multisense::MultiSenseStatus::TemperatureStatus>(m, "TemperatureStatus")
         .def(py::init<>())
         PYBIND11_JSON_SUPPORT(multisense::MultiSenseStatus::TemperatureStatus)
+        .def_readwrite("cpu_temperature", &multisense::MultiSenseStatus::TemperatureStatus::cpu_temperature);
         .def_readwrite("fpga_temperature", &multisense::MultiSenseStatus::TemperatureStatus::fpga_temperature)
         .def_readwrite("left_imager_temperature", &multisense::MultiSenseStatus::TemperatureStatus::left_imager_temperature)
         .def_readwrite("right_imager_temperature", &multisense::MultiSenseStatus::TemperatureStatus::right_imager_temperature)
-        .def_readwrite("power_supply_temperature", &multisense::MultiSenseStatus::TemperatureStatus::power_supply_temperature);
 
     // MultiSenseStatus::PowerStatus
     py::class_<multisense::MultiSenseStatus::PowerStatus>(m, "PowerStatus")

--- a/python/bindings.cc
+++ b/python/bindings.cc
@@ -456,10 +456,10 @@ PYBIND11_MODULE(_libmultisense, m) {
     py::class_<multisense::MultiSenseStatus::TemperatureStatus>(m, "TemperatureStatus")
         .def(py::init<>())
         PYBIND11_JSON_SUPPORT(multisense::MultiSenseStatus::TemperatureStatus)
-        .def_readwrite("cpu_temperature", &multisense::MultiSenseStatus::TemperatureStatus::cpu_temperature);
+        .def_readwrite("cpu_temperature", &multisense::MultiSenseStatus::TemperatureStatus::cpu_temperature)
         .def_readwrite("fpga_temperature", &multisense::MultiSenseStatus::TemperatureStatus::fpga_temperature)
         .def_readwrite("left_imager_temperature", &multisense::MultiSenseStatus::TemperatureStatus::left_imager_temperature)
-        .def_readwrite("right_imager_temperature", &multisense::MultiSenseStatus::TemperatureStatus::right_imager_temperature)
+        .def_readwrite("right_imager_temperature", &multisense::MultiSenseStatus::TemperatureStatus::right_imager_temperature);
 
     // MultiSenseStatus::PowerStatus
     py::class_<multisense::MultiSenseStatus::PowerStatus>(m, "PowerStatus")

--- a/source/Legacy/details/public.cc
+++ b/source/Legacy/details/public.cc
@@ -1658,7 +1658,7 @@ Status impl::getDeviceStatus(system::StatusMessage& status)
     status.processingPipelineOk = (m_statusResponseMessage.status & wire::StatusResponse::STATUS_PIPELINE_OK) ==
         wire::StatusResponse::STATUS_PIPELINE_OK;
 
-    status.powerSupplyTemperature = m_statusResponseMessage.temperature0;
+    status.cpuTemperature = m_statusResponseMessage.temperature0;
     status.fpgaTemperature = m_statusResponseMessage.temperature1;
     status.leftImagerTemperature = m_statusResponseMessage.temperature2;
     status.rightImagerTemperature = m_statusResponseMessage.temperature3;

--- a/source/Legacy/include/MultiSense/MultiSenseTypes.hh
+++ b/source/Legacy/include/MultiSense/MultiSenseTypes.hh
@@ -3529,7 +3529,7 @@ class MULTISENSE_API StatusMessage {
 
         /** The temperature of the internal switching mode power supply.
          * Temperature is is Celsius */
-        float powerSupplyTemperature;
+        float cpuTemperature;
 
         /** The temperature of the FPGA. Temperature is is Celsius */
         float fpgaTemperature;
@@ -3566,7 +3566,7 @@ class MULTISENSE_API StatusMessage {
             imuOk(false),
             externalLedsOk(false),
             processingPipelineOk(false),
-            powerSupplyTemperature(0.),
+            cpuTemperature(0.),
             fpgaTemperature(0.),
             leftImagerTemperature(0.),
             rightImagerTemperature(0.),

--- a/source/Legacy/include/MultiSense/MultiSenseTypes.hh
+++ b/source/Legacy/include/MultiSense/MultiSenseTypes.hh
@@ -3527,17 +3527,16 @@ class MULTISENSE_API StatusMessage {
         /** A boolean indicating if the processing pipeline is ok */
         bool processingPipelineOk;
 
-        /** The temperature of the internal switching mode power supply.
-         * Temperature is is Celsius */
+        /** The temperature of the SoC CPU. Temperature is in Celsius */
         float cpuTemperature;
 
-        /** The temperature of the FPGA. Temperature is is Celsius */
+        /** The temperature of the FPGA. Temperature is in Celsius */
         float fpgaTemperature;
 
-        /** The temperature of the left imager. Temperature is is Celsius */
+        /** The temperature of the left imager. Temperature is in Celsius */
         float leftImagerTemperature;
 
-        /** The temperature of the right imager. Temperature is is Celsius */
+        /** The temperature of the right imager. Temperature is in Celsius */
         float rightImagerTemperature;
 
         /** The input voltage supplied to the MultiSense. Value is in Volts */

--- a/source/LibMultiSense/details/legacy/status.cc
+++ b/source/LibMultiSense/details/legacy/status.cc
@@ -49,10 +49,10 @@ bool system_ok(const crl::multisense::details::wire::StatusResponse &status)
 template <>
 MultiSenseStatus::TemperatureStatus convert(const crl::multisense::details::wire::StatusResponse &status)
 {
-    return MultiSenseStatus::TemperatureStatus{status.temperature1,
+    return MultiSenseStatus::TemperatureStatus{status.temperature0,
+                                               status.temperature1,
                                                status.temperature2,
-                                               status.temperature3,
-                                               status.temperature0};
+                                               status.temperature3};
 }
 
 template <>

--- a/source/LibMultiSense/include/MultiSense/MultiSenseSerialization.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseSerialization.hh
@@ -342,10 +342,10 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(MultiSenseStatus::CameraStatus,
                                    processing_pipeline_ok)
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(MultiSenseStatus::TemperatureStatus,
+                                   cpu_temperature,
                                    fpga_temperature,
                                    left_imager_temperature,
-                                   right_imager_temperature,
-                                   power_supply_temperature)
+                                   right_imager_temperature)
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(MultiSenseStatus::PowerStatus,
                                    input_voltage,

--- a/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
@@ -1163,7 +1163,12 @@ struct MultiSenseStatus
     struct TemperatureStatus
     {
         ///
-        /// @brief Temperature of the FPGA  in Celsius
+        /// @brief Temperature of the processing subsystem (CPU cores of SoC) in Celsius
+        ///
+        float cpu_temperature = 0.0f;
+
+        ///
+        /// @brief Temperature of the FPGA in Celsius
         ///
         float fpga_temperature = 0.0f;
 
@@ -1176,11 +1181,6 @@ struct MultiSenseStatus
         /// @brief Temperature of the right imager in Celsius
         ///
         float right_imager_temperature = 0.0f;
-
-        ///
-        /// @brief Temperature of the internal switching power supply in Celsius
-        ///
-        float power_supply_temperature = 0.0f;
     };
 
     struct PowerStatus

--- a/source/LibMultiSense/test/status_test.cc
+++ b/source/LibMultiSense/test/status_test.cc
@@ -106,10 +106,10 @@ TEST(convert, temperature)
 
     const auto temp = convert<MultiSenseStatus::TemperatureStatus>(status);
 
+    ASSERT_FLOAT_EQ(temp.cpu_temperature, status.temperature0);
     ASSERT_FLOAT_EQ(temp.fpga_temperature, status.temperature1);
     ASSERT_FLOAT_EQ(temp.left_imager_temperature, status.temperature2);
     ASSERT_FLOAT_EQ(temp.right_imager_temperature, status.temperature3);
-    ASSERT_FLOAT_EQ(temp.power_supply_temperature, status.temperature0);
 }
 
 TEST(convert, power)


### PR DESCRIPTION
Update naming to reflect underlying data returned from camera 