### PR TITLE
Simplify histograms if we are using grayscale imagers

### DIFF
--- a/source/LibMultiSense/details/legacy/channel.cc
+++ b/source/LibMultiSense/details/legacy/channel.cc
@@ -1254,7 +1254,7 @@ void LegacyChannel::handle_and_dispatch(Image image,
                          capture_time,
                          ptp_capture_time,
                          m_calibration.aux ? ColorImageEncoding::YCBCR420 : ColorImageEncoding::NONE,
-                         get_histogram(metadata),
+                         get_histogram(metadata, m_info.device.hardware_revision),
                          microseconds{metadata.exposureTime},
                          metadata.gain};
 

--- a/source/LibMultiSense/include/details/legacy/utilities.hh
+++ b/source/LibMultiSense/include/details/legacy/utilities.hh
@@ -172,7 +172,8 @@ ImuSampleScalars get_imu_scalars(const crl::multisense::details::wire::ImuInfo &
 ///
 /// @brief Extract histogram data from the image metadata
 ///
-ImageHistogram get_histogram(const crl::multisense::details::wire::ImageMeta &metadata);
+ImageHistogram get_histogram(const crl::multisense::details::wire::ImageMeta &metadata,
+                             const MultiSenseInfo::DeviceInfo::HardwareRevision &hardware_revision);
 
 ///
 /// @brief Helper to wait for ack from the camera from a given query command. Once a query


### PR DESCRIPTION
If we have a camera with grayscale stereo imagers, simplify the histogram so it only has a single channel