### PR TITLE
Remove 20.04 from the release build pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   release-assets:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-latest, windows-2022]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-latest, windows-2022]
 
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
Remove 20.04 from the release build pipeline since it's now EOL