### PR TITLE
Improve legacy channel errors

### DIFF
--- a/source/Legacy/details/channel.cc
+++ b/source/Legacy/details/channel.cc
@@ -178,7 +178,7 @@ impl::impl(const std::string& address, const RemoteHeadChannel& cameraId, const 
     try {
         bind(ifName);
     } catch (const std::exception& e) {
-        CRL_DEBUG("exception: %s\n", e.what());
+        CRL_DEBUG("failed to bind to interface %s: exception: %s\n", ifName.c_str(), e.what());
         cleanup();
         throw e;
     }
@@ -205,7 +205,7 @@ impl::impl(const std::string& address, const RemoteHeadChannel& cameraId, const 
     if (Status_Ok != status)
     {
       cleanup();
-      CRL_EXCEPTION("failed to establish comms with the sensor at \"%s\", with remote head enum %d",
+      CRL_EXCEPTION("failed to stop data streams with the sensor at \"%s\", with remote head enum %d",
                     address.c_str(), cameraId);
     }
 
@@ -217,7 +217,7 @@ impl::impl(const std::string& address, const RemoteHeadChannel& cameraId, const 
     status = waitData(wire::SysGetMtu(), mtu);
     if (Status_Ok != status) {
         cleanup();
-        CRL_EXCEPTION("failed to establish comms with the sensor at \"%s\", with remote head enum %d",
+        CRL_EXCEPTION("failed to get the mtu of the sensor at \"%s\", with remote head enum %d",
                       address.c_str(), cameraId);
     } else {
 

--- a/source/Legacy/include/MultiSense/details/channel.hh
+++ b/source/Legacy/include/MultiSense/details/channel.hh
@@ -301,7 +301,7 @@ private:
     static CRL_CONSTEXPR uint32_t RX_POOL_SMALL_BUFFER_COUNT    = 256;
     static CRL_CONSTEXPR uint32_t MAX_BUFFER_ALLOCATION_RETRIES = 5;
 
-    static double DEFAULT_ACK_TIMEOUT ()         { return 0.5; }
+    static double DEFAULT_ACK_TIMEOUT ()         { return 1.0; }
     static CRL_CONSTEXPR uint32_t DEFAULT_ACK_ATTEMPTS              = 5;
     static CRL_CONSTEXPR uint32_t IMAGE_META_CACHE_DEPTH            = 4;
     static CRL_CONSTEXPR uint32_t SECONDARY_APP_META_CACHE_DEPTH    = 4;


### PR DESCRIPTION
Add more details for LibMultiSense construction errors. Increase ACK timeout to 1s