### PR TITLE
Add aux depth computation utilites

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,12 +578,15 @@ def main():
             print("Unable to start streams")
             exit(1)
 
+        # Set to true to save the depth image in the frame of the aux color camera
+        in_aux_frame = False
+
         while True:
             frame = channel.get_next_image_frame()
             if frame:
                 # MONO16 depth images are quantized to 1 mm per 1 pixel value to match the OpenNI standard.
                 # For example, a depth image pixel with a value of 10 would correspond to a depth of 10mm
-                depth_image = lms.create_depth_image(frame, lms.PixelFormat.MONO16, lms.DataSource.LEFT_DISPARITY_RAW, 65535)
+                depth_image = lms.create_depth_image(frame, lms.PixelFormat.MONO16, lms.DataSource.LEFT_DISPARITY_RAW, in_aux_frame, 65535)
                 if depth_image:
                     print("Saving depth image for frame id: ", frame.frame_id)
                     cv2.imwrite(str(frame.frame_id) + ".png", depth_image.as_array)
@@ -622,6 +625,9 @@ int main(int argc, char** argv)
         return 1;
     }
 
+    // Set to true to save the depth image in the frame of the aux color camera
+    const bool in_aux_frame = false;
+
     while(!done)
     {
         if (const auto image_frame = channel->get_next_image_frame(); image_frame)
@@ -632,6 +638,7 @@ int main(int argc, char** argv)
             if (const auto depth_image = lms::create_depth_image(image_frame.value(),
                                                                  lms::Image::PixelFormat::MONO16,
                                                                  lms::DataSource::LEFT_DISPARITY_RAW,
+                                                                 in_aux_frame,
                                                                  65535); depth_image)
             {
                 std::cout << "Saving depth image for frame id: " << image_frame->frame_id << std::endl;

--- a/python/bindings.cc
+++ b/python/bindings.cc
@@ -699,6 +699,15 @@ PYBIND11_MODULE(_libmultisense, m) {
         .def("set_network_config", &multisense::Channel::set_network_config, py::call_guard<py::gil_scoped_release>());
 
     // Utilities
+    py::class_<multisense::QMatrix>(m, "QMatrix")
+        .def(py::init<const multisense::CameraCalibration &, const multisense::CameraCalibration &>())
+        .def("reproject", &multisense::QMatrix::reproject);
+
+    py::class_<multisense::Pixel>(m, "Pixel")
+        .def(py::init<>())
+        .def_readwrite("u", &multisense::Pixel::u)
+        .def_readwrite("y", &multisense::Pixel::v);
+
     py::class_<multisense::Point<void>>(m, "Point")
         .def(py::init<>())
         .def_readwrite("x", &multisense::Point<void>::x)
@@ -949,6 +958,8 @@ PYBIND11_MODULE(_libmultisense, m) {
             py::call_guard<py::gil_scoped_release>());
 
     m.def("create_depth_image", &multisense::create_depth_image, py::call_guard<py::gil_scoped_release>());
+
+    m.def("get_aux_3d_point", &multisense::get_aux_3d_point, py::call_guard<py::gil_scoped_release>());
 
     m.def("create_bgr_from_ycbcr420", &multisense::create_bgr_from_ycbcr420, py::call_guard<py::gil_scoped_release>());
 

--- a/source/LibMultiSense/details/utilities.cc
+++ b/source/LibMultiSense/details/utilities.cc
@@ -47,6 +47,7 @@
 #endif
 
 #include <algorithm>
+#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <stdexcept>
@@ -217,7 +218,6 @@ std::optional<Image> create_depth_image(const ImageFrame &frame,
     const double tx_aux = compute_in_aux_frame ? frame.calibration.aux->P[0][3] / frame.calibration.aux->P[0][0] : 0.0;
     const double baseline_ratio = tx_aux / tx;
 
-
     auto data = std::make_shared<std::vector<uint8_t>>();
 
     switch (depth_format)
@@ -226,7 +226,7 @@ std::optional<Image> create_depth_image(const ImageFrame &frame,
         {
             data->resize(disparity.width * disparity.height * sizeof(uint16_t));
             const std::vector<uint16_t> raw_data(disparity.width * disparity.height, static_cast<uint16_t>(invalid_value));
-            memcpy(data->data(), raw_data.data(), data->size());
+            std::memcpy(data->data(), raw_data.data(), data->size());
 
             break;
         }
@@ -234,7 +234,7 @@ std::optional<Image> create_depth_image(const ImageFrame &frame,
         {
             data->resize(disparity.width * disparity.height * sizeof(float));
             const std::vector<float> raw_data(disparity.width * disparity.height, static_cast<float>(invalid_value));
-            memcpy(data->data(), raw_data.data(), data->size());
+            std::memcpy(data->data(), raw_data.data(), data->size());
             break;
         }
         default:

--- a/source/LibMultiSense/details/utilities.cc
+++ b/source/LibMultiSense/details/utilities.cc
@@ -358,7 +358,7 @@ std::optional<Point<void>> get_aux_3d_point(const ImageFrame &frame,
             break;
         }
 
-        const size_t index = disparity.image_data_offset + (search_u + (rectified_aux_pixel.v * disparity.width) * sizeof(uint16_t));
+        const size_t index = disparity.image_data_offset + ((search_u + (rectified_aux_pixel.v * disparity.width)) * sizeof(uint16_t));
 
         const double d =
             static_cast<double>(*reinterpret_cast<const uint16_t*>(disparity.raw_data->data() + index)) * scale;
@@ -368,7 +368,7 @@ std::optional<Point<void>> get_aux_3d_point(const ImageFrame &frame,
             continue;
         }
 
-        if ((rectified_aux_pixel.u + (baseline_ratio * d)) < pixel_epsilon)
+        if (std::abs((rectified_aux_pixel.u + (baseline_ratio * d)) - search_u) < pixel_epsilon)
         {
             return Q.reproject(Pixel{search_u, rectified_aux_pixel.v}, d);
         }

--- a/source/LibMultiSense/include/MultiSense/MultiSenseUtilities.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseUtilities.hh
@@ -99,19 +99,21 @@ MULTISENSE_API bool write_image(const Image &image, const std::filesystem::path 
 /// @brief Create a depth image from a image frame
 ///
 /// @param depth_format Supported formats include MONO16 and FLOAT32. Note MONO16 will be quantized to millimeters)
+/// @param compute_in_aux_frame Compute the depth image so it's returned in the aux camera's image frame
 /// @param invalid_value The value to set invalid depth measurements to. (i.e. points where disparity = 0)
 ///
 MULTISENSE_API std::optional<Image> create_depth_image(const ImageFrame &frame,
                                                        const Image::PixelFormat &depth_format,
                                                        const DataSource &disparity_source = DataSource::LEFT_DISPARITY_RAW,
+                                                       bool compute_in_aux_frame = false,
                                                        float invalid_value = 0);
 
 ///
 /// @brief Convert a YCbCr420 luma + chroma image into a BGR color image
 ///
 MULTISENSE_API std::optional<Image> create_bgr_from_ycbcr420(const Image &luma,
-                                                              const Image &chroma,
-                                                              const DataSource &output_source);
+                                                             const Image &chroma,
+                                                             const DataSource &output_source);
 
 ///
 /// @brief Convert a YCbCr420 luma + chroma image into a BGR color image

--- a/source/Utilities/LibMultiSense/SaveImageUtility/SaveImageUtility.cc
+++ b/source/Utilities/LibMultiSense/SaveImageUtility/SaveImageUtility.cc
@@ -163,7 +163,7 @@ int main(int argc, char** argv)
     bool save_color = false;
 
     int c;
-    while(-1 != (c = getopt(argc, argv, "a:m:n:dlc")))
+    while(-1 != (c = getopt(argc, argv, "a:m:n:xdlc")))
     {
         switch(c)
         {

--- a/source/Utilities/LibMultiSense/SaveImageUtility/SaveImageUtility.cc
+++ b/source/Utilities/LibMultiSense/SaveImageUtility/SaveImageUtility.cc
@@ -70,12 +70,13 @@ void usage(const char *name)
     std::cerr << "\t-m <mtu>                : MTU to use to communicate with the camera (default=1500)" << std::endl;
     std::cerr << "\t-n <number-of-images>   : Number of images to save (default=1)" << std::endl;
     std::cerr << "\t-d                      : Save depth images" << std::endl;
+    std::cerr << "\t-x                      : Save aux depth images" << std::endl;
     std::cerr << "\t-l                      : Save left rectified images" << std::endl;
     std::cerr << "\t-c                      : Save color images" << std::endl;
     exit(1);
 }
 
-void save_image(const lms::ImageFrame &frame, const lms::DataSource &source)
+void save_image(const lms::ImageFrame &frame, const lms::DataSource &source, bool save_depth, bool save_aux_depth)
 {
     const auto base_path = std::to_string(frame.frame_id) +  "_" +
                           std::to_string(static_cast<int>(source));
@@ -83,13 +84,30 @@ void save_image(const lms::ImageFrame &frame, const lms::DataSource &source)
     {
         case lms::DataSource::LEFT_DISPARITY_RAW:
         {
-            if (const auto depth_image = lms::create_depth_image(frame,
-                                                                 lms::Image::PixelFormat::MONO16,
-                                                                 source,
-                                                                 65535); depth_image)
+            if (save_depth)
             {
-                lms::write_image(depth_image.value(), base_path + ".pgm");
+                if (const auto depth_image = lms::create_depth_image(frame,
+                                                                     lms::Image::PixelFormat::MONO16,
+                                                                     source,
+                                                                     false,
+                                                                     65535); depth_image)
+                {
+                    lms::write_image(depth_image.value(), base_path + ".pgm");
+                }
             }
+
+            if (save_aux_depth)
+            {
+                if (const auto depth_image = lms::create_depth_image(frame,
+                                                                     lms::Image::PixelFormat::MONO16,
+                                                                     source,
+                                                                     true,
+                                                                     65535); depth_image)
+                {
+                    lms::write_image(depth_image.value(), base_path + "_aux.pgm");
+                }
+            }
+
             break;
         }
         case lms::DataSource::LEFT_RECTIFIED_RAW:
@@ -140,6 +158,7 @@ int main(int argc, char** argv)
     int16_t mtu = 1500;
     size_t number_of_images = 1;
     bool save_depth = false;
+    bool save_aux_depth = false;
     bool save_left_rect = false;
     bool save_color = false;
 
@@ -152,6 +171,7 @@ int main(int argc, char** argv)
             case 'm': mtu = static_cast<uint16_t>(atoi(optarg)); break;
             case 'n': number_of_images = static_cast<size_t>(atoi(optarg)); break;
             case 'd': save_depth = true; break;
+            case 'x': save_aux_depth = true; break;
             case 'l': save_left_rect = true; break;
             case 'c': save_color = true; break;
             default: usage(*argv); break;
@@ -187,7 +207,7 @@ int main(int argc, char** argv)
     }
 
     std::vector<lms::DataSource> image_streams{};
-    if (save_depth) image_streams.push_back(lms::DataSource::LEFT_DISPARITY_RAW);
+    if (save_depth || save_aux_depth) image_streams.push_back(lms::DataSource::LEFT_DISPARITY_RAW);
     if (save_left_rect) image_streams.push_back(lms::DataSource::LEFT_RECTIFIED_RAW);
     if (save_color) image_streams.push_back(lms::DataSource::AUX_RAW);
 
@@ -206,9 +226,6 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    //
-    // Only save the first image
-    //
     size_t saved_images = 0;
 
     while(!done)
@@ -219,7 +236,7 @@ int main(int argc, char** argv)
             {
                 for (const auto &stream : image_streams)
                 {
-                    save_image(image_frame.value(), stream);
+                    save_image(image_frame.value(), stream, save_depth, save_aux_depth);
                 }
 
                 ++saved_images;

--- a/source/Utilities/LibMultiSense/SaveImageUtility/save_image_utility.py
+++ b/source/Utilities/LibMultiSense/SaveImageUtility/save_image_utility.py
@@ -62,13 +62,20 @@ def get_status_string(status):
 
     return output + temp + power + stats
 
-def save_image(frame, source):
+def save_image(frame, source, save_depth, save_aux_depth):
     base_path = str(frame.frame_id) + "_" + str(source);
 
     if source == lms.DataSource.LEFT_DISPARITY_RAW:
-        depth_image = lms.create_depth_image(frame, lms.PixelFormat.MONO16, lms.DataSource.LEFT_DISPARITY_RAW, 65535)
-        if depth_image:
-            lms.write_image(depth_image, base_path + ".pgm")
+        if save_depth:
+            depth_image = lms.create_depth_image(frame, lms.PixelFormat.MONO16, lms.DataSource.LEFT_DISPARITY_RAW, False, 65535)
+            if depth_image:
+                lms.write_image(depth_image, base_path + ".pgm")
+
+        if save_aux_depth:
+            depth_image = lms.create_depth_image(frame, lms.PixelFormat.MONO16, lms.DataSource.LEFT_DISPARITY_RAW, True, 65535)
+            if depth_image:
+                lms.write_image(depth_image, base_path + "_aux.pgm")
+
     elif source == lms.DataSource.LEFT_RECTIFIED_RAW:
         lms.write_image(frame.get_image(source), base_path + ".pgm")
     elif source == lms.DataSource.AUX_RAW:
@@ -100,7 +107,7 @@ def main(args):
             exit(1)
 
         streams = []
-        if args.save_depth:
+        if args.save_depth or args.save_aux_depth:
             streams.append(lms.DataSource.LEFT_DISPARITY_RAW)
         if args.save_left_rect:
             streams.append(lms.DataSource.LEFT_RECTIFIED_RAW)
@@ -118,7 +125,7 @@ def main(args):
                 frame = channel.get_next_image_frame()
                 if frame:
                     for stream in streams:
-                        save_image(frame, stream)
+                        save_image(frame, stream, args.save_depth, args.save_aux_depth)
 
                     saved_images += 1
 
@@ -134,6 +141,7 @@ if __name__ == '__main__':
     parser.add_argument("-m", "--mtu", type=int, default=1500, help="The MTU to use to communicate with the camera.")
     parser.add_argument("-n", "--number-of-images", type=int, default=1, help="The number of images to save.")
     parser.add_argument("-d", "--save-depth", action='store_true', help="Save a 16 bit depth image.")
+    parser.add_argument("-x", "--save-aux-depth", action='store_true', help="Save a 16 bit depth image in the aux frame.")
     parser.add_argument("-l", "--save-left-rect", action='store_true', help="Save a left rectified image.")
     parser.add_argument("-c", "--save-color", action='store_true', help="Save a color image.")
     main(parser.parse_args())


### PR DESCRIPTION
- Update create_depth_image utility to create a depth image in the aux camera frame
- Add the ability to query the 3D depth for a single aux pixel
- Generalize the re-projection of disparity to 3D