### PR TITLE
feat: ignore RTPS datagrams

### DIFF
--- a/source/Legacy/details/dispatch.cc
+++ b/source/Legacy/details/dispatch.cc
@@ -883,14 +883,25 @@ void impl::handle()
         const wire::Header& header = *(reinterpret_cast<const wire::Header*>(inP));
 
         if (wire::HEADER_MAGIC != header.magic)
+        {
+            if (wire::ignoredUdpProtocol(m_incomingBuffer))
+            {
+                continue;
+            }
+
             CRL_EXCEPTION("bad protocol magic: 0x%x, expecting 0x%x",
                           header.magic, wire::HEADER_MAGIC);
+        }
         else if (wire::HEADER_VERSION != header.version)
+        {
             CRL_EXCEPTION("bad protocol version: 0x%x, expecting 0x%x",
                           header.version, wire::HEADER_VERSION);
+        }
         else if (wire::HEADER_GROUP != header.group)
+        {
             CRL_EXCEPTION("bad protocol group: 0x%x, expecting 0x%x",
                           header.group, wire::HEADER_GROUP);
+        }
 
         //
         // Unwrap the sequence identifier

--- a/source/LibMultiSense/details/legacy/message.cc
+++ b/source/LibMultiSense/details/legacy/message.cc
@@ -109,6 +109,11 @@ bool header_valid(const std::vector<uint8_t> &raw_data)
 
     if (wire::HEADER_MAGIC != header.magic)
     {
+        if (wire::ignoredUdpProtocol(m_incomingBuffer))
+        {
+            return false;
+        }
+
         CRL_DEBUG("bad protocol magic: 0x%x, expecting 0x%x\n", header.magic, wire::HEADER_MAGIC);
         return false;
     }

--- a/source/LibMultiSense/details/legacy/message.cc
+++ b/source/LibMultiSense/details/legacy/message.cc
@@ -109,12 +109,11 @@ bool header_valid(const std::vector<uint8_t> &raw_data)
 
     if (wire::HEADER_MAGIC != header.magic)
     {
-        if (wire::ignoredUdpProtocol(m_incomingBuffer))
+        if (!wire::ignoredUdpProtocol(raw_data))
         {
-            return false;
+            CRL_DEBUG("bad protocol magic: 0x%x, expecting 0x%x\n", header.magic, wire::HEADER_MAGIC);
         }
 
-        CRL_DEBUG("bad protocol magic: 0x%x, expecting 0x%x\n", header.magic, wire::HEADER_MAGIC);
         return false;
     }
     else if (wire::HEADER_VERSION != header.version)

--- a/source/Wire/include/wire/Protocol.hh
+++ b/source/Wire/include/wire/Protocol.hh
@@ -40,6 +40,7 @@
 
 #include <stdint.h>
 #include <string.h>
+#include <vector>
 
 #include "../utility/Portability.hh"
 
@@ -368,16 +369,14 @@ static CRL_CONSTEXPR float WIRE_IMAGER_GAIN_MAX = 1000.0f;
 
 inline bool ignoredUdpProtocol(const std::vector<uint8_t>& dgramPayload)
 {
+    //
     // Ignore RTPS headers
-    if (dgramPayload.size() < 20) // minimum RTPS header size, but only read 4 bytes
-    {
-        static uint8_t rtps_magic[4] = {0x52, 0x54, 0x50, 0x53}; // RTPS
-        if (memcmp(dgramPayload.data(), rtps_magic, sizeof(rtps_magic)) == 0)
-        {
-            return true;
-        }
-    }
-    return false;
+    // Minimum RTPS header size is 20, but only need to read the first 4 bytes
+    return (dgramPayload.size() < 20 &&
+            dgramPayload[0] == 0x52 && // R
+            dgramPayload[1] == 0x54 && // T
+            dgramPayload[2] == 0x50 && // P
+            dgramPayload[3] == 0x53); // S
 }
 
 }}}} // namespaces

--- a/source/Wire/include/wire/Protocol.hh
+++ b/source/Wire/include/wire/Protocol.hh
@@ -39,6 +39,7 @@
 #define LibMultiSense_details_wire_protocol
 
 #include <stdint.h>
+#include <string.h>
 
 #include "../utility/Portability.hh"
 
@@ -361,6 +362,23 @@ static CRL_CONSTEXPR float WIRE_IMAGER_GAIN_MAX = 1000.0f;
     for(uint32_t i_=0; i_<(n_); i_++)           \
         for(uint32_t j_=0; j_<(m_); j_++)       \
             (d_)[i_][j_] = (s_)[i_][j_];        \
+
+//
+// Some helper functions
+
+inline bool ignoredUdpProtocol(const std::vector<uint8_t>& dgramPayload)
+{
+    // Ignore RTPS headers
+    if (dgramPayload.size() < 20) // minimum RTPS header size, but only read 4 bytes
+    {
+        static uint8_t rtps_magic[4] = {0x52, 0x54, 0x50, 0x53}; // RTPS
+        if (memcmp(dgramPayload.data(), rtps_magic, sizeof(rtps_magic)) == 0)
+        {
+            return true;
+        }
+    }
+    return false;
+}
 
 }}}} // namespaces
 


### PR DESCRIPTION
RTPS headers will come in on whatever port DDS assigns them to.

Obviously, this isn't a 100% guarantee that the packet is RTPS, but the [protocol description here](https://community.rti.com/static/documentation/wireshark/2020-07/doc/understanding_rtps.html) makes it clear that the magic number is ASCII "RTPS".

Disclaimer: This was not tested, so will need to be tested on a system experiencing this issue. I just added the check and toss the packet, I do no additional debug. Unsure what the preferred behavior is, but often times RTPS packets will be seen on autonomous systems, and this could become noisy.