### PR TITLE
Force a min version of gcc/clang to support std::filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,24 +72,40 @@ if (NOT BUILD_LEGACY_API)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
     #
-    # Ensure compiler support for std::filesystem (GCC 9.0+)
+    # Ensure compiler support for std::filesystem
     #
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
-            message(FATAL_ERROR "GCC 9.0 or higher is required for std::filesystem support in the new MultiSense API. Current version: ${CMAKE_CXX_COMPILER_VERSION}")
+
+    set(FILESYSTEM_CODE "
+        #include <filesystem>
+        int main() {
+            std::filesystem::path p(\"/\");
+            return std::filesystem::exists(p) ? 0 : 1;
+        }
+    ")
+
+    check_cxx_source_compiles("${FILESYSTEM_CODE}" HAVE_STD_FILESYSTEM)
+
+    if (NOT HAVE_STD_FILESYSTEM)
+        # Try linking with stdc++fs (GCC < 9, Clang < 9)
+        set(CMAKE_REQUIRED_LIBRARIES stdc++fs)
+        check_cxx_source_compiles("${FILESYSTEM_CODE}" HAVE_STD_FILESYSTEM_STDCXXFS)
+        if (HAVE_STD_FILESYSTEM_STDCXXFS)
+            set(FILESYSTEM_LIBRARY stdc++fs)
+            set(HAVE_STD_FILESYSTEM TRUE)
+        else()
+            # Try linking with c++fs (older Clang/libc++)
+            set(CMAKE_REQUIRED_LIBRARIES c++fs)
+            check_cxx_source_compiles("${FILESYSTEM_CODE}" HAVE_STD_FILESYSTEM_CXXFS)
+            if (HAVE_STD_FILESYSTEM_CXXFS)
+                set(FILESYSTEM_LIBRARY c++fs)
+                set(HAVE_STD_FILESYSTEM TRUE)
+            endif()
         endif()
-    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
-            message(FATAL_ERROR "Clang 7.0 or higher is required for std::filesystem support in the new MultiSense API. Current version: ${CMAKE_CXX_COMPILER_VERSION}")
-        endif()
-    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.3)
-            message(FATAL_ERROR "AppleClang 10.3 or higher is required for std::filesystem support in the new MultiSense API. Current version: ${CMAKE_CXX_COMPILER_VERSION}")
-        endif()
-    elseif(MSVC)
-         if(MSVC_VERSION LESS 1914)
-            message(FATAL_ERROR "MSVC 19.14 (Visual Studio 2017 15.7) or higher is required for std::filesystem support in the new MultiSense API.")
-        endif()
+        unset(CMAKE_REQUIRED_LIBRARIES)
+    endif()
+
+    if (NOT HAVE_STD_FILESYSTEM)
+        message(FATAL_ERROR "The new MultiSense API requires a compiler with std::filesystem support (C++17).")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,27 @@ endif ()
 if (NOT BUILD_LEGACY_API)
     set(CMAKE_CXX_STANDARD 17)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+    #
+    # Ensure compiler support for std::filesystem (GCC 9.0+)
+    #
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+            message(FATAL_ERROR "GCC 9.0 or higher is required for std::filesystem support in the new MultiSense API. Current version: ${CMAKE_CXX_COMPILER_VERSION}")
+        endif()
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
+            message(FATAL_ERROR "Clang 7.0 or higher is required for std::filesystem support in the new MultiSense API. Current version: ${CMAKE_CXX_COMPILER_VERSION}")
+        endif()
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+        if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.3)
+            message(FATAL_ERROR "AppleClang 10.3 or higher is required for std::filesystem support in the new MultiSense API. Current version: ${CMAKE_CXX_COMPILER_VERSION}")
+        endif()
+    elseif(MSVC)
+         if(MSVC_VERSION LESS 1914)
+            message(FATAL_ERROR "MSVC 19.14 (Visual Studio 2017 15.7) or higher is required for std::filesystem support in the new MultiSense API.")
+        endif()
+    endif()
 endif()
 
 #

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -8,7 +8,8 @@ pybind11_add_module(_libmultisense MODULE bindings.cc)
 target_link_libraries(
     _libmultisense
     PRIVATE
-    MultiSense)
+    MultiSense
+    ${FILESYSTEM_LIBRARY})
 
 if (BUILD_JSON_SERIALIZATION)
     message("Building python bindings with json print support")

--- a/source/LibMultiSense/CMakeLists.txt
+++ b/source/LibMultiSense/CMakeLists.txt
@@ -30,7 +30,7 @@ else()
 
 endif()
 
-target_link_libraries(MultiSense MultiSenseWire)
+target_link_libraries(MultiSense MultiSenseWire ${FILESYSTEM_LIBRARY})
 target_include_directories(MultiSense
         PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         PUBLIC $<INSTALL_INTERFACE:include>)

--- a/source/Utilities/LibMultiSense/CMakeLists.txt
+++ b/source/Utilities/LibMultiSense/CMakeLists.txt
@@ -3,6 +3,7 @@ find_package(Threads REQUIRED)
 list(APPEND MULTISENSE_UTILITY_LIBS
     MultiSense
     Threads::Threads
+    ${FILESYSTEM_LIBRARY}
 )
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows" OR CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")


### PR DESCRIPTION
Ensure our compiler natively supports std::filesystem