### PR TITLE
change how lighting type is determined for KS21(i)

### DIFF
--- a/source/LibMultiSense/details/legacy/configuration.cc
+++ b/source/LibMultiSense/details/legacy/configuration.cc
@@ -35,6 +35,7 @@
  **/
 
 #include <algorithm>
+#include <iostream>
 
 #include "details/legacy/configuration.hh"
 #include "details/legacy/utilities.hh"
@@ -99,7 +100,7 @@ MultiSenseConfig convert(const crl::multisense::details::wire::CamConfig &config
                                 std::make_optional(convert(imu_config.value(), imu_info.value())) :
                                 std::nullopt,
                             (led_config && led_config->available) ?
-                                std::make_optional(convert(led_config.value(), info.lighting_type)) :
+                                std::make_optional(convert(led_config.value(), info)) :
                                 std::nullopt};
 }
 
@@ -371,7 +372,7 @@ crl::multisense::details::wire::ImuConfig convert(const MultiSenseConfig::ImuCon
 }
 
 MultiSenseConfig::LightingConfig convert(const crl::multisense::details::wire::LedStatus &led,
-                                         const MultiSenseInfo::DeviceInfo::LightingType &type)
+                                         const MultiSenseInfo::DeviceInfo &devinfo)
 {
     using lighting = MultiSenseConfig::LightingConfig;
 
@@ -380,7 +381,7 @@ MultiSenseConfig::LightingConfig convert(const crl::multisense::details::wire::L
     std::optional<lighting::InternalConfig> internal = std::nullopt;
     std::optional<lighting::ExternalConfig> external = std::nullopt;
 
-    switch (type)
+    switch (devinfo.lighting_type)
     {
         case MultiSenseInfo::DeviceInfo::LightingType::NONE:
         {
@@ -395,7 +396,6 @@ MultiSenseConfig::LightingConfig convert(const crl::multisense::details::wire::L
 
         case MultiSenseInfo::DeviceInfo::LightingType::EXTERNAL:
         case MultiSenseInfo::DeviceInfo::LightingType::OUTPUT_TRIGGER:
-        case MultiSenseInfo::DeviceInfo::LightingType::PATTERN_PROJECTOR_OUTPUT_TRIGGER:
         {
             lighting::ExternalConfig::FlashMode mode = lighting::ExternalConfig::FlashMode::NONE;
 
@@ -409,6 +409,28 @@ MultiSenseConfig::LightingConfig convert(const crl::multisense::details::wire::L
             }
 
             external = lighting::ExternalConfig{intensity, mode, led.number_of_pulses, std::chrono::microseconds{led.led_delay_us}};
+            break;
+        }
+        case MultiSenseInfo::DeviceInfo::LightingType::PATTERN_PROJECTOR_OUTPUT_TRIGGER:
+        {
+            if (devinfo.hardware_revision == MultiSenseInfo::DeviceInfo::HardwareRevision::KS21i){
+                std::cout << "Detected KS21i lighting - external\n";
+                lighting::ExternalConfig::FlashMode mode = lighting::ExternalConfig::FlashMode::NONE;
+                if (led.rolling_shutter_led)
+                {
+                    mode = lighting::ExternalConfig::FlashMode::SYNC_WITH_AUX;
+                }
+                else if (led.flash)
+                {
+                    mode = lighting::ExternalConfig::FlashMode::SYNC_WITH_MAIN_STEREO;
+                }
+
+                external = lighting::ExternalConfig{intensity, mode, led.number_of_pulses, std::chrono::microseconds{led.led_delay_us}};
+            } else {
+                std::cout << "Detected KS21 standard lighting - internal\n";
+                internal = lighting::InternalConfig{intensity, led.flash != 0};
+            }
+
             break;
         }
         default:{CRL_EXCEPTION("Unsupported lighting type\n");}

--- a/source/LibMultiSense/details/legacy/configuration.cc
+++ b/source/LibMultiSense/details/legacy/configuration.cc
@@ -35,7 +35,6 @@
  **/
 
 #include <algorithm>
-#include <iostream>
 
 #include "details/legacy/configuration.hh"
 #include "details/legacy/utilities.hh"
@@ -413,8 +412,8 @@ MultiSenseConfig::LightingConfig convert(const crl::multisense::details::wire::L
         }
         case MultiSenseInfo::DeviceInfo::LightingType::PATTERN_PROJECTOR_OUTPUT_TRIGGER:
         {
-            if (devinfo.hardware_revision == MultiSenseInfo::DeviceInfo::HardwareRevision::KS21i){
-                std::cout << "Detected KS21i lighting - external\n";
+            if (devinfo.hardware_revision == MultiSenseInfo::DeviceInfo::HardwareRevision::KS21i)
+            {
                 lighting::ExternalConfig::FlashMode mode = lighting::ExternalConfig::FlashMode::NONE;
                 if (led.rolling_shutter_led)
                 {
@@ -426,8 +425,9 @@ MultiSenseConfig::LightingConfig convert(const crl::multisense::details::wire::L
                 }
 
                 external = lighting::ExternalConfig{intensity, mode, led.number_of_pulses, std::chrono::microseconds{led.led_delay_us}};
-            } else {
-                std::cout << "Detected KS21 standard lighting - internal\n";
+            }
+            else
+            {
                 internal = lighting::InternalConfig{intensity, led.flash != 0};
             }
 

--- a/source/LibMultiSense/include/details/legacy/configuration.hh
+++ b/source/LibMultiSense/include/details/legacy/configuration.hh
@@ -108,7 +108,7 @@ crl::multisense::details::wire::ImuConfig convert(const MultiSenseConfig::ImuCon
 /// @brief Convert a wire lighting config to a API lighting config
 ///
 MultiSenseConfig::LightingConfig convert(const crl::multisense::details::wire::LedStatus &led,
-                                         const MultiSenseInfo::DeviceInfo::LightingType &type);
+                                         const MultiSenseInfo::DeviceInfo &devinfo);
 
 ///
 /// @brief Convert a API lighting config to a wire lighting config

--- a/source/LibMultiSense/test/configuration_test.cc
+++ b/source/LibMultiSense/test/configuration_test.cc
@@ -726,8 +726,9 @@ TEST(convert, imu_config_limit_messages)
 TEST(convert, lighting_config_round_trip)
 {
     const auto wire_config = create_valid_lighting_wire_config();
+    const auto device_info = create_device_info(1920, 1200);
 
-    const auto config = convert(wire_config, multisense::MultiSenseInfo::DeviceInfo::LightingType::EXTERNAL);
+    const auto config = convert(wire_config, device_info);
 
     check_equal(config, wire_config);
     check_equal(config, convert(config));


### PR DESCRIPTION
Untested, just looking to make sure it builds and get initial feedback on if we want to have it in its own case to be explicit (as shown), or add the selection logic to the existing fallthough case. 

@dougbalish1 TODO: Cleanup debug prints after testing