### PR TITLE
cmake: Specify relative `RPATH` for install-time prefixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,11 +130,19 @@ else()
 endif()
 
 #
-# Use full RPATH
+# Specify a relative RPATH to support both configure-time and install-time prefixes.
 #
 set (CMAKE_SKIP_BUILD_RPATH FALSE)
 set (CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-set (CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
+if(APPLE)
+    set(CMAKE_INSTALL_RPATH "@loader_path/../lib")
+elseif(UNIX)
+    # [[ ]] keeps $ORIGIN literal for the linker instead of letting CMake expand it.
+    set(CMAKE_INSTALL_RPATH [[$ORIGIN/../lib]])
+else()
+    # RPATH is not supported for non-ELF platforms. Keep the configure-time default.
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+endif()
 set (CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 #


### PR DESCRIPTION
Replace the configure-time `${CMAKE_INSTALL_PREFIX}/lib` install RPATH with paths relative to each installed artifact, so the installed tree is relocatable and works whether the prefix is provided at configure time (`-DCMAKE_INSTALL_PREFIX=...`) or at install time (`cmake --install <build-dir> --prefix <dir>`).

Fixes #279.

## Testing

I have only tested this on a Linux system.  This leaves the Apple path untested.  The Windows/other path is just the previous behavior.