### PR TITLE
fix: add missing Threads dependency

### DIFF
--- a/source/Legacy/MultiSenseConfig.cmake.in
+++ b/source/Legacy/MultiSenseConfig.cmake.in
@@ -2,6 +2,7 @@
 
 include(CMakeFindDependencyMacro)
 find_dependency(MultiSenseWire)
+find_dependency(Threads)
 
 include("${CMAKE_CURRENT_LIST_DIR}/MultiSenseTargets.cmake")
 


### PR DESCRIPTION
When building with the Legacy API, `Threads::Threads` could not be found