### PR TITLE
Fix failing unit test and add image write error handling

### DIFF
--- a/source/LibMultiSense/details/utilities.cc
+++ b/source/LibMultiSense/details/utilities.cc
@@ -243,8 +243,16 @@ cv::Mat FeatureMessage::cv_descriptors() const
 
 bool write_image(const Image &image, const std::filesystem::path &path)
 {
-#ifdef HAVE_OPENCV
-    return cv::imwrite(path.string(), image.cv_mat());
+#ifdef MULTISENSE_HAVE_OPENCV
+    try
+    {
+        return cv::imwrite(path.string(), image.cv_mat());
+    }
+    catch (const cv::Exception &e)
+    {
+        CRL_DEBUG("Failed to write image to disk: %s", e.what());
+        return false;
+    }
 #else
     const auto extension = path.extension();
     if (extension == ".pgm" || extension == ".PGM" || extension == ".ppm" || extension == ".PPM")

--- a/source/LibMultiSense/test/multisense_utilities_test.cc
+++ b/source/LibMultiSense/test/multisense_utilities_test.cc
@@ -561,7 +561,7 @@ TEST(write_image, unsupported_extension)
               DataSource::LEFT_MONO_RAW,
               aux_calibration};
 
-    const auto path = std::filesystem::temp_directory_path() / "test.png";
+    const auto path = std::filesystem::temp_directory_path() / "test.unsupported";
     EXPECT_FALSE(write_image(img, path));
 }
 


### PR DESCRIPTION
Fix failing `write_image.unsupported_extension` unit test and add some handling to prevent similar errors.

Fixes #292.
