### PR TITLE
Namespace OpenCV compile definition and make `PUBLIC`

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,7 +682,6 @@ if __name__ == "__main__":
 
 #include <opencv2/opencv.hpp>
 
-#define HAVE_OPENCV 1
 #include <MultiSense/MultiSenseChannel.hh>
 #include <MultiSense/MultiSenseUtilities.hh>
 
@@ -777,7 +776,6 @@ if __name__ == "__main__":
 
 #include <opencv2/opencv.hpp>
 
-#define HAVE_OPENCV 1
 #include <MultiSense/MultiSenseChannel.hh>
 #include <MultiSense/MultiSenseUtilities.hh>
 
@@ -1264,7 +1262,6 @@ if __name__ == "__main__":
 #include <iostream>
 #include <opencv2/opencv.hpp>
 
-#define HAVE_OPENCV 1
 #include <MultiSense/MultiSenseChannel.hh>
 #include <MultiSense/MultiSenseUtilities.hh>
 

--- a/source/LibMultiSense/CMakeLists.txt
+++ b/source/LibMultiSense/CMakeLists.txt
@@ -37,7 +37,7 @@ target_include_directories(MultiSense
 
 if (BUILD_OPENCV)
   if(OpenCV_FOUND)
-    target_compile_definitions(MultiSense PRIVATE HAVE_OPENCV)
+    target_compile_definitions(MultiSense PUBLIC MULTISENSE_HAVE_OPENCV)
 
     target_include_directories(MultiSense PUBLIC ${OpenCV_INCLUDE_DIRS})
 

--- a/source/LibMultiSense/details/utilities.cc
+++ b/source/LibMultiSense/details/utilities.cc
@@ -53,7 +53,7 @@
 #include <iostream>
 #include <stdexcept>
 
-#ifdef HAVE_OPENCV
+#ifdef MULTISENSE_HAVE_OPENCV
 #include <opencv2/imgcodecs.hpp>
 #include <opencv2/features2d.hpp>
 #endif
@@ -64,7 +64,7 @@
 namespace multisense {
 namespace {
 
-#ifndef HAVE_OPENCV
+#ifndef MULTISENSE_HAVE_OPENCV
 bool write_binary_image(const Image &image, const std::filesystem::path &path)
 {
     std::ofstream output(path, std::ios::binary | std::ios::out);
@@ -193,7 +193,7 @@ std::string to_string(const DataSource &source)
 }
 
 
-#ifdef HAVE_OPENCV
+#ifdef MULTISENSE_HAVE_OPENCV
 cv::Mat Image::cv_mat() const
 {
     int cv_type = 0;

--- a/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
@@ -47,7 +47,7 @@
 #include <tuple>
 #include <vector>
 
-#ifdef HAVE_OPENCV
+#ifdef MULTISENSE_HAVE_OPENCV
 #include <opencv2/core/mat.hpp>
 #endif
 
@@ -289,7 +289,7 @@ struct Image
         return std::nullopt;
     }
 
-#ifdef HAVE_OPENCV
+#ifdef MULTISENSE_HAVE_OPENCV
     ///
     /// @brief Transform a image into a cv::Mat object if the user wants to build OpenCV utilities
     ///        The cv::Mat returned here wraps the underlying image data pointer associated with
@@ -392,7 +392,7 @@ struct FeatureMessage
     ///
     std::vector<uint8_t> descriptors{};
 
-#ifdef HAVE_OPENCV
+#ifdef MULTISENSE_HAVE_OPENCV
     ///
     /// @brief Convert keypoints to native OpenCV keypoints
     ///

--- a/source/LibMultiSense/test/feature_test.cc
+++ b/source/LibMultiSense/test/feature_test.cc
@@ -40,7 +40,7 @@
 #include <MultiSense/wire/FeatureMessage.hh>
 #include <MultiSense/wire/FeatureMetaMessage.hh>
 
-#ifdef HAVE_OPENCV
+#ifdef MULTISENSE_HAVE_OPENCV
 #include <opencv2/core.hpp>
 #include <opencv2/features2d.hpp>
 #endif
@@ -90,7 +90,7 @@ TEST(ImageFrame, Features)
     EXPECT_EQ(frame.frame_id, 1234);
 }
 
-#ifdef HAVE_OPENCV
+#ifdef MULTISENSE_HAVE_OPENCV
 TEST(FeatureMessage, OpenCVConversion)
 {
     FeatureMessage msg;

--- a/source/Utilities/LibMultiSense/FeatureDetectorUtility/CMakeLists.txt
+++ b/source/Utilities/LibMultiSense/FeatureDetectorUtility/CMakeLists.txt
@@ -1,9 +1,9 @@
-if(OpenCV_FOUND)
+if(BUILD_OPENCV AND OpenCV_FOUND)
     add_executable(FeatureDetectorUtility FeatureDetectorUtility.cc)
 
     target_link_libraries (FeatureDetectorUtility ${MULTISENSE_UTILITY_LIBS})
 
     install(TARGETS FeatureDetectorUtility RUNTIME DESTINATION "bin")
 else()
-    message("Missing OpenCV. Not building the c++ FeatureDetectorUtility")
+    message(STATUS "Missing OpenCV or BUILD_OPENCV is OFF. Not building the C++ FeatureDetectorUtility")
 endif()

--- a/source/Utilities/LibMultiSense/FeatureDetectorUtility/FeatureDetectorUtility.cc
+++ b/source/Utilities/LibMultiSense/FeatureDetectorUtility/FeatureDetectorUtility.cc
@@ -49,7 +49,6 @@
 #include <iostream>
 #include <thread>
 
-#define HAVE_OPENCV 1
 #include <opencv2/features2d.hpp>
 #include <opencv2/highgui.hpp>
 #include <opencv2/imgproc.hpp>


### PR DESCRIPTION
Replace the private `HAVE_OPENCV` compile definition with the public `MULTISENSE_HAVE_OPENCV`.  This new definition leaks to library consumers, so the `#define HAVE_OPENCV 1` line is no longer needed in consumer source files.

This may be part of the issue seen in #294.
