### PR TITLE
Fix Windows DLL exports for OpenCV helper methods

### DIFF
--- a/source/LibMultiSense/CMakeLists.txt
+++ b/source/LibMultiSense/CMakeLists.txt
@@ -27,6 +27,7 @@ else()
     add_library(MultiSense STATIC ${MULTISENSE_HEADERS}
                                    ${DETAILS_SRC})
     set_target_properties(MultiSense PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    target_compile_definitions(MultiSense PUBLIC MultiSense_STATIC)
 
 endif()
 

--- a/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
@@ -52,11 +52,17 @@
 #endif
 
 #if !defined(MULTISENSE_API)
-#if defined (_MSC_VER)
-#define MULTISENSE_API __declspec(dllexport)
-#else
-#define MULTISENSE_API
-#endif
+#  if defined (_MSC_VER)
+#    if defined (MultiSense_STATIC)
+#      define MULTISENSE_API
+#    elif defined (MultiSense_EXPORTS)
+#      define MULTISENSE_API __declspec(dllexport)
+#    else
+#      define MULTISENSE_API __declspec(dllimport)
+#    endif
+#  else
+#    define MULTISENSE_API
+#  endif
 #endif
 
 

--- a/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseTypes.hh
@@ -303,7 +303,7 @@ struct Image
     ///        the corresponding cv::Mat, you will need to `clone` the cv::Mat creating an internal copy
     ///        of all the data
     ///
-    cv::Mat cv_mat() const;
+    MULTISENSE_API cv::Mat cv_mat() const;
 #endif
 };
 
@@ -402,7 +402,7 @@ struct FeatureMessage
     ///
     /// @brief Convert keypoints to native OpenCV keypoints
     ///
-    std::vector<cv::KeyPoint> cv_keypoints() const;
+    MULTISENSE_API std::vector<cv::KeyPoint> cv_keypoints() const;
 
     ///
     /// @brief Convert descriptors to a native OpenCV Mat.
@@ -411,7 +411,7 @@ struct FeatureMessage
     ///        still using the corresponding cv::Mat, you will need to `clone` the cv::Mat creating an internal
     ///        copy of all the data
     ///
-    cv::Mat cv_descriptors() const;
+    MULTISENSE_API cv::Mat cv_descriptors() const;
 #endif
 };
 

--- a/source/LibMultiSense/include/MultiSense/MultiSenseUtilities.hh
+++ b/source/LibMultiSense/include/MultiSense/MultiSenseUtilities.hh
@@ -256,10 +256,10 @@ MULTISENSE_API CameraCalibration scale_calibration(CameraCalibration calibration
 /// @return Return a colorized point cloud
 ///
 template<typename Color>
-MULTISENSE_API std::optional<PointCloud<Color>> create_color_pointcloud(const Image &disparity,
-                                                                        const std::optional<Image> &color,
-                                                                        double max_range,
-                                                                        const StereoCalibration &calibration)
+std::optional<PointCloud<Color>> create_color_pointcloud(const Image &disparity,
+                                                         const std::optional<Image> &color,
+                                                         double max_range,
+                                                         const StereoCalibration &calibration)
 {
     size_t color_step = 0;
     double color_disparity_scale = 0.0;
@@ -359,10 +359,10 @@ MULTISENSE_API std::optional<PointCloud<Color>> create_color_pointcloud(const Im
 /// @return Return a colorized point cloud
 ///
 template<typename Color>
-MULTISENSE_API std::optional<PointCloud<Color>> create_color_pointcloud(const ImageFrame &frame,
-                                                                        double max_range,
-                                                                        const DataSource &color_source = DataSource::UNKNOWN,
-                                                                        const DataSource &disparity_source = DataSource::LEFT_DISPARITY_RAW)
+std::optional<PointCloud<Color>> create_color_pointcloud(const ImageFrame &frame,
+                                                         double max_range,
+                                                         const DataSource &color_source = DataSource::UNKNOWN,
+                                                         const DataSource &disparity_source = DataSource::LEFT_DISPARITY_RAW)
 {
     if constexpr (std::is_same_v<Color, void>)
     {
@@ -399,7 +399,7 @@ MULTISENSE_API std::optional<PointCloud<void>> create_pointcloud(const ImageFram
 /// @return Return true if the pointcloud was written successfully
 ///
 template <typename Color>
-MULTISENSE_API bool write_pointcloud_ply(const PointCloud<Color> &point_cloud, const std::filesystem::path &path)
+bool write_pointcloud_ply(const PointCloud<Color> &point_cloud, const std::filesystem::path &path)
 {
     std::ofstream ply(path, std::ios::binary);
     if (!ply.good())


### PR DESCRIPTION
Fix Windows shared-library builds with OpenCV support enabled.

When building with OpenCV and utilities on Windows, `FeatureDetectorUtility` failed to link because the OpenCV helper methods on `Image` and `FeatureMessage` were compiled into `MultiSense` but not exported from `MultiSense.dll` (see #292).

Redefine the `MULTISENSE_API` decoration to follow standard MSVC behavior:
- `MultiSense_EXPORTS` uses `__declspec(dllexport)`
- DLL consumers use `__declspec(dllimport)`
- `MultiSense_STATIC` uses no decoration

Also...
- mark the offending OpenCV helper methods with the `MULTISENSE_API` decorator
- remove the decorator from header-defined template methods as they do not need to be marked for import.

Another partial fix to #292.
