### PR TITLE
cmake: Export namespaced library targets

### DIFF
--- a/ci/library-consumption-test/CMakeLists.txt
+++ b/ci/library-consumption-test/CMakeLists.txt
@@ -47,6 +47,12 @@ if (CONSUME_OPENCV)
 endif()
 
 add_executable(multisense_consumption_test main.cc)
+
+# Link against the legacy `MultiSense` target rather than the modern, namespaced
+# `MultiSense::MultiSense` target.  The package configuration will forward the
+# legacy target to the namespaced target, thus evaluating both paths in a single
+# test.
+# TODO: Remove this when the legacy `MultiSense` target is removed.
 target_link_libraries(multisense_consumption_test PRIVATE MultiSense)
 
 if (CONSUME_JSON_SERIALIZATION)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -8,7 +8,7 @@ pybind11_add_module(_libmultisense MODULE bindings.cc)
 target_link_libraries(
     _libmultisense
     PRIVATE
-    MultiSense
+    MultiSense::MultiSense
     ${FILESYSTEM_LIBRARY})
 
 if (BUILD_JSON_SERIALIZATION)

--- a/source/Legacy/CMakeLists.txt
+++ b/source/Legacy/CMakeLists.txt
@@ -59,7 +59,11 @@ add_library(MultiSense ${MULTISENSE_HEADERS}
                        ${DETAILS_HEADERS}
                        ${DETAILS_SRC})
 
-target_link_libraries(MultiSense PUBLIC MultiSenseWire)
+# Provide a namespaced alias so that in-tree consumers can link against the same
+# target name that the installed package exports.
+add_library(MultiSense::MultiSense ALIAS MultiSense)
+
+target_link_libraries(MultiSense PUBLIC MultiSenseWire::MultiSenseWire)
 target_include_directories(MultiSense
         PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         PUBLIC $<INSTALL_INTERFACE:include>)
@@ -110,6 +114,7 @@ install(TARGETS MultiSense
 )
 
 install(EXPORT MultiSenseTargets
+  NAMESPACE MultiSense::
   DESTINATION lib/cmake/MultiSense)
 
 write_basic_package_version_file(

--- a/source/Legacy/MultiSenseConfig.cmake.in
+++ b/source/Legacy/MultiSenseConfig.cmake.in
@@ -19,4 +19,15 @@ endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/MultiSenseTargets.cmake")
 
+# The exported target is namespaced as `MultiSense::MultiSense`.  Historically,
+# this was simply `MultiSense`.  For backwards compatibility, recreate the
+# legacy `MultiSense` target as an interface that forwards to the current,
+# namespaced target.
+# TODO: Remove this legacy support in a future, major release.
+if (NOT TARGET MultiSense AND TARGET MultiSense::MultiSense)
+    add_library(MultiSense INTERFACE IMPORTED)
+    set_target_properties(MultiSense PROPERTIES
+        INTERFACE_LINK_LIBRARIES MultiSense::MultiSense)
+endif()
+
 check_required_components(MultiSense)

--- a/source/LibMultiSense/CMakeLists.txt
+++ b/source/LibMultiSense/CMakeLists.txt
@@ -31,7 +31,11 @@ else()
 
 endif()
 
-target_link_libraries(MultiSense PRIVATE MultiSenseWire)
+# Provide a namespaced alias so that in-tree consumers can link against the same
+# target name that the installed package exports.
+add_library(MultiSense::MultiSense ALIAS MultiSense)
+
+target_link_libraries(MultiSense PRIVATE MultiSenseWire::MultiSenseWire)
 if (FILESYSTEM_LIBRARY)
     target_link_libraries(MultiSense PUBLIC ${FILESYSTEM_LIBRARY})
 endif()
@@ -96,6 +100,7 @@ install(TARGETS MultiSense
 )
 
 install(EXPORT MultiSenseTargets
+        NAMESPACE MultiSense::
         DESTINATION lib/cmake/MultiSense)
 
 write_basic_package_version_file(

--- a/source/LibMultiSense/MultiSenseConfig.cmake.in
+++ b/source/LibMultiSense/MultiSenseConfig.cmake.in
@@ -29,4 +29,15 @@ endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/MultiSenseTargets.cmake")
 
+# The exported target is namespaced as `MultiSense::MultiSense`.  Historically,
+# this was simply `MultiSense`.  For backwards compatibility, recreate the
+# legacy `MultiSense` target as an interface that forwards to the current,
+# namespaced target.
+# TODO: Remove this legacy support in a future, major release.
+if (NOT TARGET MultiSense AND TARGET MultiSense::MultiSense)
+    add_library(MultiSense INTERFACE IMPORTED)
+    set_target_properties(MultiSense PROPERTIES
+        INTERFACE_LINK_LIBRARIES MultiSense::MultiSense)
+endif()
+
 check_required_components(MultiSense)

--- a/source/LibMultiSense/test/CMakeLists.txt
+++ b/source/LibMultiSense/test/CMakeLists.txt
@@ -14,8 +14,8 @@ set(TEST_NAMES
 
 foreach(TEST_NAME ${TEST_NAMES})
     add_executable(${TEST_NAME} ${TEST_NAME}.cc)
-    target_link_libraries(${TEST_NAME} PRIVATE MultiSense
-                                               MultiSenseWire
+    target_link_libraries(${TEST_NAME} PRIVATE MultiSense::MultiSense
+                                               MultiSenseWire::MultiSenseWire
                                                GTest::GTest GTest::Main)
 
     add_test(${TEST_NAME} ${TEST_NAME})

--- a/source/Utilities/Legacy/CMakeLists.txt
+++ b/source/Utilities/Legacy/CMakeLists.txt
@@ -10,7 +10,7 @@ include_directories(shared)
 
 find_package(Threads REQUIRED)
 list(APPEND MULTISENSE_UTILITY_LIBS
-    MultiSense
+    MultiSense::MultiSense
     Threads::Threads
 )
 

--- a/source/Utilities/LibMultiSense/CMakeLists.txt
+++ b/source/Utilities/LibMultiSense/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 find_package(Threads REQUIRED)
 list(APPEND MULTISENSE_UTILITY_LIBS
-    MultiSense
+    MultiSense::MultiSense
     Threads::Threads
     ${FILESYSTEM_LIBRARY}
 )

--- a/source/Wire/CMakeLists.txt
+++ b/source/Wire/CMakeLists.txt
@@ -124,6 +124,10 @@ else()
 
 endif()
 
+# Provide a namespaced alias so that in-tree consumers can link against the same
+# target name that the installed package exports.
+add_library(MultiSenseWire::MultiSenseWire ALIAS MultiSenseWire)
+
 target_compile_definitions(MultiSenseWire PRIVATE MultiSense_EXPORTS=True)
 if (MULTISENSE_USE_MONOTONIC_CLOCK)
     target_compile_definitions(MultiSenseWire PRIVATE USE_MONOTONIC_CLOCK=${MULTISENSE_USE_MONOTONIC_CLOCK})
@@ -165,7 +169,8 @@ install(TARGETS MultiSenseWire
 )
 
 install(EXPORT MultiSenseWireTargets
-DESTINATION lib/cmake/MultiSenseWire)
+  NAMESPACE MultiSenseWire::
+  DESTINATION lib/cmake/MultiSenseWire)
 
 install(FILES ${WIRE_HEADERS} DESTINATION include/MultiSense/wire)
 install(FILES ${UTILITY_HEADERS} DESTINATION include/MultiSense/utility)

--- a/source/Wire/MultiSenseWireConfig.cmake.in
+++ b/source/Wire/MultiSenseWireConfig.cmake.in
@@ -2,4 +2,15 @@
 
 include("${CMAKE_CURRENT_LIST_DIR}/MultiSenseWireTargets.cmake")
 
+# The exported target is namespaced as `MultiSenseWire::MultiSenseWire`.
+# Historically, this was simply `MultiSenseWire`.  For backwards compatibility,
+# recreate the legacy `MultiSenseWire` target as an interface that forwards to
+# the current, namespaced target.
+# TODO: Remove this legacy support in a future, major release.
+if (NOT TARGET MultiSenseWire AND TARGET MultiSenseWire::MultiSenseWire)
+    add_library(MultiSenseWire INTERFACE IMPORTED)
+    set_target_properties(MultiSenseWire PROPERTIES
+        INTERFACE_LINK_LIBRARIES MultiSenseWire::MultiSenseWire)
+endif()
+
 check_required_components(MultiSenseWire)

--- a/source/Wire/test/CMakeLists.txt
+++ b/source/Wire/test/CMakeLists.txt
@@ -5,7 +5,7 @@ set(TEST_NAMES
 
 foreach(TEST_NAME ${TEST_NAMES})
     add_executable(${TEST_NAME} ${TEST_NAME}.cc)
-    target_link_libraries(${TEST_NAME} PRIVATE MultiSenseWire
+    target_link_libraries(${TEST_NAME} PRIVATE MultiSenseWire::MultiSenseWire
                                                GTest::GTest GTest::Main)
 
     add_test(${TEST_NAME} ${TEST_NAME})


### PR DESCRIPTION
Update CMake to export namespaced targets, conforming to the modern library standard practice.  Behavior is preserved for consumers using the legacy, unnamespaced targets via new interface libraries generated in the package configuration files.  Also update all in-library links to use the namespaced targets.

Now, users of `LibMultiSense` will consume it as follows.
```cmake
find_package(MultiSense)
add_library(MyLib my_lib.cpp)
target_link_libraries(MyLib PRIVATE MultiSense::MultiSense)
```

Resolves #306.