### PR TITLE
ci: Do not manually search for OpenCV dependency

### DIFF
--- a/ci/library-consumption-test/CMakeLists.txt
+++ b/ci/library-consumption-test/CMakeLists.txt
@@ -41,11 +41,6 @@ option(CONSUME_OPENCV
 
 find_package(MultiSense REQUIRED)
 
-# FIXME: This should be handled by the consumer fixture, not the consumer.
-if (CONSUME_OPENCV)
-    find_package(OpenCV REQUIRED)
-endif()
-
 add_executable(multisense_consumption_test main.cc)
 
 # Link against the legacy `MultiSense` target rather than the modern, namespaced


### PR DESCRIPTION
Remove a now-outdated practice in the CI's library consumer test fixture CMake that would manually attempt to find the OpenCV target if it was not available. This was a holdover from before a fix for this issue was implemented via #299.  Now, OpenCV will be automatically searched for via the package configuration file's `find_dependency()` calls.

Resolves #310.